### PR TITLE
Replace Math.random with secure RNG

### DIFF
--- a/20240824-DenominatorNeglect.html
+++ b/20240824-DenominatorNeglect.html
@@ -11,7 +11,7 @@
             const qna = [{'question': "What is 'denominator neglect'?", 'answer': 'Denominator neglect is a cognitive bias where people focus more on the numerator than the denominator, leading to a distorted perception of risk and probability.'}, {'question': 'How does imagery affect the perception of risk?', 'answer': 'Vivid imagery, like imagining a single red marble among white ones, can enhance the perception of likelihood, even when the statistical probability remains unchanged.'}, {'question': 'How can the communication of risks influence perception?', 'answer': 'The way risks are communicated can significantly influence perception, with certain phrasings creating more vivid images and stronger emotional responses.'}, {'question': "What is the 'frequency format effect'?", 'answer': 'The frequency format effect refers to how people judge risks differently based on how they are presented, often misjudging risks when they focus on raw numbers rather than percentages.'}, {'question': 'Are experienced professionals immune to denominator neglect?', 'answer': 'No, even experienced professionals like forensic psychologists and psychiatrists can be influenced by denominator neglect, as shown in experiments involving risk assessment.'}];
 
             // Randomly pick a QnA
-            const randomIndex = Math.floor(Math.random() * qna.length);
+            const randomIndex = Math.floor(getSecureRandomNumber() * qna.length);
             const selectedQnA = qna[randomIndex];
 
             // Show the question first

--- a/20240824-FactorPriceDetermination.html
+++ b/20240824-FactorPriceDetermination.html
@@ -32,7 +32,7 @@
             ];
 
             // Randomly pick a QnA
-            const randomIndex = Math.floor(Math.random() * qna.length);
+            const randomIndex = Math.floor(getSecureRandomNumber() * qna.length);
             const selectedQnA = qna[randomIndex];
 
             // Show the question first

--- a/20240824-JusticeTelosHonor.html
+++ b/20240824-JusticeTelosHonor.html
@@ -11,7 +11,7 @@
             const qna = [{'question': 'What does Aristotle mean by saying justice is teleological?', 'answer': 'Justice is teleological means that determining rights requires understanding the purpose or end of a social practice.'}, {'question': 'How does Aristotle connect justice to honor?', 'answer': 'Aristotle believes that reasoning about justice involves reasoning about what virtues a practice should honor and reward.'}, {'question': "What is a modern theory of justice's approach to fairness and rights?", 'answer': 'Modern theories often try to separate questions of fairness and rights from arguments about honor, virtue, and moral desert.'}, {'question': "How does Aristotle's view on justice differ from utilitarian views?", 'answer': "Aristotle's view focuses on honoring individual merit and virtue, while utilitarian views emphasize producing the greatest happiness for the greatest number."}, {'question': 'What is essential to understanding Aristotle’s ethics and politics?', 'answer': "Understanding the force of both teleological and honorific considerations and their relation is key to Aristotle's ethics and politics."}];
 
             // Randomly pick a QnA
-            const randomIndex = Math.floor(Math.random() * qna.length);
+            const randomIndex = Math.floor(getSecureRandomNumber() * qna.length);
             const selectedQnA = qna[randomIndex];
 
             // Show the question first

--- a/2025-1-pm.html
+++ b/2025-1-pm.html
@@ -308,7 +308,7 @@
         ];
 
         document.getElementById('fetch-record').addEventListener('click', () => {
-            const randomIndex = Math.floor(Math.random() * csvData.length);
+            const randomIndex = Math.floor(getSecureRandomNumber() * csvData.length);
             const randomRecord = csvData[randomIndex];
             document.getElementById('record').textContent = randomRecord;
         });

--- a/240822-conversational-japanese-technique.html
+++ b/240822-conversational-japanese-technique.html
@@ -17,7 +17,7 @@
 
         function showRandomQnA() {
             const keys = Object.keys(qna);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             alert(randomKey);
             alert(qna[randomKey]);
         }

--- a/240822-econ-glossary.html
+++ b/240822-econ-glossary.html
@@ -44,7 +44,7 @@
 
         function showRandomGlossaryItem() {
             const keys = Object.keys(glossary);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             alert(glossary[randomKey]);
             alert(randomKey);
         }

--- a/240822-golf-course-mgt.html
+++ b/240822-golf-course-mgt.html
@@ -17,7 +17,7 @@
 
         function showRandomQnA() {
             const keys = Object.keys(qna);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             alert(randomKey);
             alert(qna[randomKey]);
         }

--- a/240822-ikanNiYorazu.html
+++ b/240822-ikanNiYorazu.html
@@ -15,7 +15,7 @@
 
         function showRandomQnA() {
             const keys = Object.keys(qna);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             alert(randomKey);
             alert(qna[randomKey]);
         }

--- a/240822-kotonashiniwa.html
+++ b/240822-kotonashiniwa.html
@@ -15,7 +15,7 @@
 
         function showRandomQnA() {
             const keys = Object.keys(qna);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             alert(randomKey);
             alert(qna[randomKey]);
         }

--- a/240822-location-game-analysis-solution.html
+++ b/240822-location-game-analysis-solution.html
@@ -16,7 +16,7 @@
 
         function showRandomQnA() {
             const keys = Object.keys(qna);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             alert(randomKey);
             alert(qna[randomKey]);
         }

--- a/240822-location-game-analysis.html
+++ b/240822-location-game-analysis.html
@@ -16,7 +16,7 @@
 
         function showRandomQnA() {
             const keys = Object.keys(qna);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             alert(randomKey);
             alert(qna[randomKey]);
         }

--- a/240822-marginal-productivity.html
+++ b/240822-marginal-productivity.html
@@ -21,7 +21,7 @@
 
         function showRandomQnA() {
             const keys = Object.keys(qna);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             alert(randomKey);
             alert(qna[randomKey]);
         }

--- a/240822-nari.html
+++ b/240822-nari.html
@@ -15,7 +15,7 @@
 
         function showRandomQnA() {
             const keys = Object.keys(qna);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             alert(randomKey);
             alert(qna[randomKey]);
         }

--- a/240822-wages-funds.html
+++ b/240822-wages-funds.html
@@ -18,7 +18,7 @@
 
         function showRandomQnA() {
             const keys = Object.keys(qna);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             alert(randomKey);
             alert(qna[randomKey]);
         }

--- a/240823-AD_AS_QnA_Randomizer.html
+++ b/240823-AD_AS_QnA_Randomizer.html
@@ -21,7 +21,7 @@
         // Function to pick a random QnA and display it
         function randomQnA() {
             const keys = Object.keys(qnaSet);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             const randomValue = qnaSet[randomKey];
             alert(randomKey);
             alert(randomValue);

--- a/240823-Financial_Concepts_QnA_Randomizer.html
+++ b/240823-Financial_Concepts_QnA_Randomizer.html
@@ -30,7 +30,7 @@
         // Function to pick a random QnA and display it
         function randomQnA() {
             const keys = Object.keys(qnaSet);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             const randomValue = qnaSet[randomKey];
             alert(randomKey);
             alert(randomValue);

--- a/240823-Government_Budget_QnA_Randomizer.html
+++ b/240823-Government_Budget_QnA_Randomizer.html
@@ -20,7 +20,7 @@
         // Function to pick a random QnA and display it
         function randomQnA() {
             const keys = Object.keys(qnaSet);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             const randomValue = qnaSet[randomKey];
             alert(randomKey);
             alert(randomValue);

--- a/240823-Human_Capital_Wages_QnA_Randomizer_Body_Complete.html
+++ b/240823-Human_Capital_Wages_QnA_Randomizer_Body_Complete.html
@@ -21,7 +21,7 @@
         // Function to pick a random QnA and display it
         function randomQnA() {
             const keys = Object.keys(qnaSet);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             const randomValue = qnaSet[randomKey];
             alert(randomKey);
             alert(randomValue);

--- a/240823-Immiserizing_Growth_QnA_Randomizer.html
+++ b/240823-Immiserizing_Growth_QnA_Randomizer.html
@@ -20,7 +20,7 @@
         // Function to pick a random QnA and display it
         function randomQnA() {
             const keys = Object.keys(qnaSet);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             const randomValue = qnaSet[randomKey];
             alert(randomKey);
             alert(randomValue);

--- a/240823-Inflation_Budget_Deficits_QnA_Randomizer.html
+++ b/240823-Inflation_Budget_Deficits_QnA_Randomizer.html
@@ -20,7 +20,7 @@
         // Function to pick a random QnA and display it
         function randomQnA() {
             const keys = Object.keys(qnaSet);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             const randomValue = qnaSet[randomKey];
             alert(randomKey);
             alert(randomValue);

--- a/240823-Pricing_Strategies_QnA_Randomizer.html
+++ b/240823-Pricing_Strategies_QnA_Randomizer.html
@@ -22,7 +22,7 @@
         // Function to pick a random QnA and display it
         function randomQnA() {
             const keys = Object.keys(qnaSet);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             const randomValue = qnaSet[randomKey];
             alert(randomKey);
             alert(randomValue);

--- a/240823-Product_Termination_QnA_Randomizer.html
+++ b/240823-Product_Termination_QnA_Randomizer.html
@@ -19,7 +19,7 @@
         // Function to pick a random QnA and display it
         function randomQnA() {
             const keys = Object.keys(qnaSet);
-            const randomKey = keys[Math.floor(Math.random() * keys.length)];
+            const randomKey = keys[Math.floor(getSecureRandomNumber() * keys.length)];
             const randomValue = qnaSet[randomKey];
             alert(randomKey);
             alert(randomValue);

--- a/240824-Financial_Analysis_QnA_Fixed.html
+++ b/240824-Financial_Analysis_QnA_Fixed.html
@@ -16,7 +16,7 @@
 
         function shuffleArray(array) {
             for (let i = array.length - 1; i > 0; i--) {
-                const j = Math.floor(Math.random() * (i + 1));
+                const j = Math.floor(getSecureRandomNumber() * (i + 1));
                 [array[i], array[j]] = [array[j], array[i]];
             }
         }

--- a/240824-Inflation_Wealth_Redistribution.html
+++ b/240824-Inflation_Wealth_Redistribution.html
@@ -16,7 +16,7 @@
 
         function shuffleArray(array) {
             for (let i = array.length - 1; i > 0; i--) {
-                const j = Math.floor(Math.random() * (i + 1));
+                const j = Math.floor(getSecureRandomNumber() * (i + 1));
                 [array[i], array[j]] = [array[j], array[i]];
             }
         }

--- a/240824-Japanese_Grammar_Analysis.html
+++ b/240824-Japanese_Grammar_Analysis.html
@@ -44,7 +44,7 @@
 
         // Function to trigger Q&A randomizer
         function triggerRandomQA() {
-            const randomIndex = Math.floor(Math.random() * qaSet.length);
+            const randomIndex = Math.floor(getSecureRandomNumber() * qaSet.length);
             const selectedQA = qaSet[randomIndex];
 
             // First alert with the question

--- a/240824-Quality_Management.html
+++ b/240824-Quality_Management.html
@@ -16,7 +16,7 @@
 
         function shuffleArray(array) {
             for (let i = array.length - 1; i > 0; i--) {
-                const j = Math.floor(Math.random() * (i + 1));
+                const j = Math.floor(getSecureRandomNumber() * (i + 1));
                 [array[i], array[j]] = [array[j], array[i]];
             }
         }

--- a/240824-Stock_Index_Futures.html
+++ b/240824-Stock_Index_Futures.html
@@ -16,7 +16,7 @@
 
         function shuffleArray(array) {
             for (let i = array.length - 1; i > 0; i--) {
-                const j = Math.floor(Math.random() * (i + 1));
+                const j = Math.floor(getSecureRandomNumber() * (i + 1));
                 [array[i], array[j]] = [array[j], array[i]];
             }
         }

--- a/240824-japanese-grammar-analysis-2.html
+++ b/240824-japanese-grammar-analysis-2.html
@@ -24,7 +24,7 @@
                 "The sentence translates to 'The answer of many people is that it is because of a weak will.'"
             ];
 
-            const randomIndex = Math.floor(Math.random() * questions.length);
+            const randomIndex = Math.floor(getSecureRandomNumber() * questions.length);
             alert(questions[randomIndex]);
             alert(answers[randomIndex]);
         }

--- a/240824-japanese-grammar-analysis.html
+++ b/240824-japanese-grammar-analysis.html
@@ -24,7 +24,7 @@
                 "The sentence translates to 'Because it was so [extreme], it resulted in an abnormal outcome.'"
             ];
 
-            const randomIndex = Math.floor(Math.random() * questions.length);
+            const randomIndex = Math.floor(getSecureRandomNumber() * questions.length);
             alert(questions[randomIndex]);
             alert(answers[randomIndex]);
         }

--- a/240824-japanese_sentence_analysis.html
+++ b/240824-japanese_sentence_analysis.html
@@ -19,7 +19,7 @@
 
     <script>
         function getRandomInt(max) {
-            return Math.floor(Math.random() * max);
+            return Math.floor(getSecureRandomNumber() * max);
         }
 
         const questions = [

--- a/240824-kotodashi.html
+++ b/240824-kotodashi.html
@@ -30,7 +30,7 @@
         ];
 
         window.onload = function() {
-            const randomQnA = qna[Math.floor(Math.random() * qna.length)];
+            const randomQnA = qna[Math.floor(getSecureRandomNumber() * qna.length)];
             alert("Question: " + randomQnA.question);
             alert("Answer: " + randomQnA.answer);
         };

--- a/48-laws-of-power-bucket.html
+++ b/48-laws-of-power-bucket.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker with Customizable Settings</title>
     <!-- Bootstrap CSS -->
@@ -44,11 +45,6 @@
         let urlPrefix = ''; // URL Prefix
         let urlSuffix = ''; // URL Suffix
 
-        function getSecureRandomNumber() {
-          const array = new Uint32Array(1);
-          window.crypto.getRandomValues(array);
-          return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Simplified list of URL bodies and frequencies
         // let initialFiles = [

--- a/allocator.html
+++ b/allocator.html
@@ -101,7 +101,7 @@
             console.log("Ranges:", ranges);
 
             // Step 2: Pick a random number within the total weighted range
-            let randomWeight = Math.floor(Math.random() * totalWeight);
+            let randomWeight = Math.floor(getSecureRandomNumber() * totalWeight);
             let cumulativeWeight = 0;
 
             // Step 3: Determine which range and index the random weight falls into

--- a/bucket-old.html
+++ b/bucket-old.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker</title>
     <!-- Bootstrap CSS -->
@@ -85,11 +86,6 @@
         /**
          * Function to get a secure random number between 0 (inclusive) and 1 (exclusive).
          */
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         /**
          * Function to shuffle an array in place using Fisher-Yates.
@@ -612,7 +608,7 @@
 
         // ADDED for dynamic background color
         function getRandomColor() {
-            return '#' + Math.floor(Math.random() * 16777215).toString(16);
+            return '#' + Math.floor(getSecureRandomNumber() * 16777215).toString(16);
         }
 
         /**

--- a/bucket-release-v1.html
+++ b/bucket-release-v1.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker</title>
     <!-- Bootstrap CSS -->
@@ -85,11 +86,6 @@
         /**
          * Function to get a secure random number between 0 (inclusive) and 1 (exclusive).
          */
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         /**
          * Function to shuffle an array in place using Fisher-Yates.

--- a/bucket-v2.html
+++ b/bucket-v2.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker</title>
     <!-- Bootstrap CSS -->
@@ -92,11 +93,6 @@
         /**
          * Function to get a secure random number between 0 (inclusive) and 1 (exclusive).
          */
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         /**
          * Function to shuffle an array in place using Fisher-Yates.

--- a/bucket.html
+++ b/bucket.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker</title>
     <!-- Bootstrap CSS -->
@@ -92,11 +93,6 @@
         /**
          * Function to get a secure random number between 0 (inclusive) and 1 (exclusive).
          */
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         /**
          * Function to shuffle an array in place using Fisher-Yates.

--- a/clairvoyance-2025.html
+++ b/clairvoyance-2025.html
@@ -324,33 +324,33 @@
       lettersSubset = getRandomLetters(10);
 
       // Randomize category probabilities
-      let w1 = Math.random(), w2 = Math.random(), w3 = Math.random();
+      let w1 = getSecureRandomNumber(), w2 = getSecureRandomNumber(), w3 = getSecureRandomNumber();
       let sum = w1 + w2 + w3;
       probLetters = w1 / sum;
       probNumbers = w2 / sum;
       probSpecials = w3 / sum;
 
       // Random coefficients
-      randomCoefficient1 = Math.random();
+      randomCoefficient1 = getSecureRandomNumber();
       do {
-        randomCoefficient2 = Math.random();
+        randomCoefficient2 = getSecureRandomNumber();
       } while (randomCoefficient2 <= randomCoefficient1);
     }
 
     function makeDraw(userGuess) {
-      const r = Math.random();
+      const r = getSecureRandomNumber();
       let chosenCategory;
       let chosenChar;
 
       if (r < probLetters) {
         chosenCategory = "letter";
-        chosenChar = lettersSubset[Math.floor(Math.random() * lettersSubset.length)];
+        chosenChar = lettersSubset[Math.floor(getSecureRandomNumber() * lettersSubset.length)];
       } else if (r < probLetters + probNumbers) {
         chosenCategory = "number";
-        chosenChar = numbers[Math.floor(Math.random() * numbers.length)];
+        chosenChar = numbers[Math.floor(getSecureRandomNumber() * numbers.length)];
       } else {
         chosenCategory = "special";
-        chosenChar = specials[Math.floor(Math.random() * specials.length)];
+        chosenChar = specials[Math.floor(getSecureRandomNumber() * specials.length)];
       }
 
       const userCategory = getCategory(userGuess);
@@ -415,7 +415,7 @@
       const copy = [...allLetters];
       const chosen = [];
       for (let i = 0; i < count; i++) {
-        const index = Math.floor(Math.random() * copy.length);
+        const index = Math.floor(getSecureRandomNumber() * copy.length);
         chosen.push(copy[index]);
         copy.splice(index, 1);
       }

--- a/clairvoyance-trial1.html
+++ b/clairvoyance-trial1.html
@@ -69,25 +69,25 @@
       document.getElementById('feedback').textContent = '';
       
       // Random number of bars
-      const numberOfBars = Math.floor(Math.random() * (maxBars - minBars + 1)) + minBars;
+      const numberOfBars = Math.floor(getSecureRandomNumber() * (maxBars - minBars + 1)) + minBars;
 
       // Random tries
-      triesLeft = Math.floor(Math.random() * 3) + 3; // e.g. 3–5 tries
+      triesLeft = Math.floor(getSecureRandomNumber() * 3) + 3; // e.g. 3–5 tries
 
       // Reset global barsData
       barsData = [];
 
       // Create each progress bar (slider) with random weight and random initial value
       for (let i = 0; i < numberOfBars; i++) {
-        const weight = Math.floor(Math.random() * 5) + 1; // Weight between 1 and 5
-        const initialValue = Math.floor(Math.random() * 101); // 0–100
+        const weight = Math.floor(getSecureRandomNumber() * 5) + 1; // Weight between 1 and 5
+        const initialValue = Math.floor(getSecureRandomNumber() * 101); // 0–100
 
         barsData.push({ weight, sliderValue: initialValue, sliderElement: null });
       }
 
       // Random target sum (you can tweak the range as you like)
       // For instance, let’s allow up to 5 * 100 * 5 = 2500 as a max
-      targetSum = Math.floor(Math.random() * 2501);
+      targetSum = Math.floor(getSecureRandomNumber() * 2501);
 
       // Build UI
       const container = document.getElementById('progressBarsContainer');

--- a/dbviewer-random.html
+++ b/dbviewer-random.html
@@ -24,7 +24,7 @@
         if (Array.isArray(raw.patches) && raw.patches.length) {
           const weights = raw.patches.map(p => Number(p.distributionWeight) || 1);
           const tot = weights.reduce((a, b) => a + b, 0);
-          let rnd = Math.random() * tot;
+          let rnd = getSecureRandomNumber() * tot;
           for (let i = 0; i < raw.patches.length; i++) {
             if (rnd < weights[i]) { patch = { ...raw.patches[i] }; break; }
             rnd -= weights[i];

--- a/dbviewer3.html
+++ b/dbviewer3.html
@@ -105,7 +105,7 @@ a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}
   /* ─── render random row ─── */
   function renderRandom(){
     if(rowCount===0){randCard.innerHTML='<p>No rows.</p>';enableBar(false);return;}
-    const offset = Math.floor(Math.random()*rowCount);
+    const offset = Math.floor(getSecureRandomNumber()*rowCount);
     const rs = db.exec(`SELECT * FROM "${table}" LIMIT 1 OFFSET ${offset}`);
     const cols = rs[0].columns, vals = rs[0].values[0]; currentRow=vals;
 

--- a/division.html
+++ b/division.html
@@ -74,7 +74,7 @@
     function getRandomInt(min, max) {
         min = Math.ceil(min);
         max = Math.floor(max);
-        return Math.floor(Math.random() * (max - min + 1)) + min;
+        return Math.floor(getSecureRandomNumber() * (max - min + 1)) + min;
     }
 
     // Initialize the numbers
@@ -99,7 +99,7 @@
     document.getElementById('revealBtn').addEventListener('click', function() {
         if (!answerRevealed) {
             // Randomly decide the division direction: true for number1 / number2, false for number2 / number1
-            const divideFirstBySecond = Math.random() < 0.5;
+            const divideFirstBySecond = getSecureRandomNumber() < 0.5;
 
             let division;
             if (divideFirstBySecond) {

--- a/drools-bucket.html
+++ b/drools-bucket.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker with Customizable Settings</title>
     <!-- Bootstrap CSS -->
@@ -44,11 +45,6 @@
         let urlPrefix = ''; // URL Prefix
         let urlSuffix = ''; // URL Suffix
 
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Constants for repetitive parts of the URLs
         const BASE_URL = "https://docs.drools.org/8.44.0.Final/drools-docs/";

--- a/drools-ralloc.html
+++ b/drools-ralloc.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Ralloc</title>
     <!-- Include Bootstrap CSS -->
@@ -237,11 +238,6 @@
     <!-- Custom JavaScript -->
     <script>
 	
-		function getSecureRandomNumber() {
-		  const array = new Uint32Array(1);
-		  window.crypto.getRandomValues(array);
-		  return array[0] / (0xFFFFFFFF + 1);
-		}
 	
         $(document).ready(function() {
             // Global variables

--- a/finetuning-bucket.html
+++ b/finetuning-bucket.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker with Customizable Settings</title>
     <!-- Bootstrap CSS -->
@@ -44,11 +45,6 @@
         let urlPrefix = ''; // URL Prefix
         let urlSuffix = ''; // URL Suffix
 
-        function getSecureRandomNumber() {
-          const array = new Uint32Array(1);
-          window.crypto.getRandomValues(array);
-          return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Simplified list of URL bodies and frequencies
         // let initialFiles = [

--- a/galloc-code.gs
+++ b/galloc-code.gs
@@ -22,7 +22,7 @@ function getRandomContentFromSheet(repo) {
     }
 
     // Randomly select a row (skipping the header row)
-    const randomIndex = Math.floor(Math.random() * (data.length - 1)) + 1;
+    const randomIndex = Math.floor(getSecureRandomNumber() * (data.length - 1)) + 1;
     const content = data[randomIndex][1]; // Assuming 'content' is in the second column
 
     return content;

--- a/galloc-index.html
+++ b/galloc-index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Data Display</title>
@@ -84,14 +85,14 @@
         const UPDATE_VISITOR_API = "https://script.google.com/macros/s/AKfycbx-c7HUH9OnQBMwDAss1WpMV0uZAs8zHwGEHSn9EIQ_hTRBKVYLiPStXQTkbhfpcS7T/exec"; // 20240819_1530
 
         function randomizeArray(arr) {
-            return arr.sort(() => Math.random() - 0.5);
+            return arr.sort(() => getSecureRandomNumber() - 0.5);
         }
 
         function randomizeObjectKeys(obj) {
             const randomizedObj = {};
 
             for (const [key, value] of Object.entries(obj)) {
-                const randomizedKeys = Object.keys(value).sort(() => Math.random() - 0.5);
+                const randomizedKeys = Object.keys(value).sort(() => getSecureRandomNumber() - 0.5);
                 const randomizedValue = {};
 
                 randomizedKeys.forEach(k => {
@@ -180,11 +181,6 @@
             }).getRandomContentFromSheet(repo);
         }
 
-        function getSecureRandomNumber() {
-          const array = new Uint32Array(1);
-          window.crypto.getRandomValues(array);
-          return array[0] / (0xFFFFFFFF + 1);
-        }
 
         function useConfigAndMods() {
             console.log("Using Config:", config);

--- a/game-diffs.html
+++ b/game-diffs.html
@@ -146,7 +146,7 @@
         let randPos = -1;
         // ensure unique positions
         do {
-          randPos = Math.floor(Math.random() * totalCells);
+          randPos = Math.floor(getSecureRandomNumber() * totalCells);
         } while (usedPositions.has(randPos));
         usedPositions.add(randPos);
 

--- a/game-lights.html
+++ b/game-lights.html
@@ -177,11 +177,11 @@
       }
 
       // randomly press some cells
-      const pressesCount = Math.floor(Math.random() * 10 + 5); 
+      const pressesCount = Math.floor(getSecureRandomNumber() * 10 + 5); 
       // Press between 5 and 14 random cells
       for (let i = 0; i < pressesCount; i++) {
-        const rr = Math.floor(Math.random() * ROWS);
-        const cc = Math.floor(Math.random() * COLS);
+        const rr = Math.floor(getSecureRandomNumber() * ROWS);
+        const cc = Math.floor(getSecureRandomNumber() * COLS);
         toggleCell(rr, cc);
       }
     }

--- a/game-maze.html
+++ b/game-maze.html
@@ -236,7 +236,7 @@
         const neighbors = getUnvisitedNeighbors(currentCell);
         if (neighbors.length > 0) {
           // choose random neighbor
-          const randIndex = Math.floor(Math.random() * neighbors.length);
+          const randIndex = Math.floor(getSecureRandomNumber() * neighbors.length);
           const nextCell = neighbors[randIndex];
 
           // push currentCell onto stack

--- a/game-minesweeper.html
+++ b/game-minesweeper.html
@@ -196,8 +196,8 @@
       // 2) Place mines randomly
       let minesToPlace = MINES;
       while (minesToPlace > 0) {
-        const randRow = Math.floor(Math.random() * ROWS);
-        const randCol = Math.floor(Math.random() * COLS);
+        const randRow = Math.floor(getSecureRandomNumber() * ROWS);
+        const randCol = Math.floor(getSecureRandomNumber() * COLS);
         if (!board[randRow][randCol].mine) {
           board[randRow][randCol].mine = true;
           minesToPlace--;

--- a/game-sliding.html
+++ b/game-sliding.html
@@ -174,7 +174,7 @@
 
       // Shuffle
       for (let i = arr.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
+        const j = Math.floor(getSecureRandomNumber() * (i + 1));
         [arr[i], arr[j]] = [arr[j], arr[i]];
       }
       return arr;

--- a/listening-bucket.html
+++ b/listening-bucket.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker with Customizable Settings</title>
     <!-- Bootstrap CSS1 -->
@@ -44,11 +45,6 @@
         let urlPrefix = ''; // URL Prefix
         let urlSuffix = ''; // URL Suffix
 
-        function getSecureRandomNumber() {
-          const array = new Uint32Array(1);
-          window.crypto.getRandomValues(array);
-          return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Simplified list of URL bodies and frequencies
         // let initialFiles = [

--- a/looptube.html
+++ b/looptube.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8">
   <title>LoopTube</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -63,9 +64,7 @@ if (modeWeightsStr) {
 if ((distributionArr && distributionArr.length) || distributionPool.length)
   randomMode='segments';
 let configValues={};
-async function loadConfig(){ if(Object.keys(configValues).length) return configValues; try{ const resp=await fetch('config/values.json'); if(resp.ok){ const raw=await resp.json(); const base=raw.base||{}; let patch={}; if(Array.isArray(raw.patches)&&raw.patches.length){ const weights=raw.patches.map(p=>Number(p.distributionWeight)||1); const tot=weights.reduce((a,b)=>a+b,0); let rnd=Math.random()*tot; for(let i=0;i<raw.patches.length;i++){ if(rnd<weights[i]){ patch={...raw.patches[i]}; break;} rnd-=weights[i]; } delete patch.distributionWeight; } configValues=Object.assign({},base,patch); } }catch(err){ console.error('Config load failed:',err);} return configValues; }
-function getSecureRandomNumber(){ const a=new Uint32Array(1); crypto.getRandomValues(a); return a[0]/(0xFFFFFFFF+1); }
-function randInt(min,max){ return Math.floor(getSecureRandomNumber()*(max-min+1))+min; }
+async function loadConfig(){ if(Object.keys(configValues).length) return configValues; try{ const resp=await fetch('config/values.json'); if(resp.ok){ const raw=await resp.json(); const base=raw.base||{}; let patch={}; if(Array.isArray(raw.patches)&&raw.patches.length){ const weights=raw.patches.map(p=>Number(p.distributionWeight)||1); const tot=weights.reduce((a,b)=>a+b,0); let rnd=getSecureRandomNumber()*tot; for(let i=0;i<raw.patches.length;i++){ if(rnd<weights[i]){ patch={...raw.patches[i]}; break;} rnd-=weights[i]; } delete patch.distributionWeight; } configValues=Object.assign({},base,patch); } }catch(err){ console.error('Config load failed:',err);} return configValues; }
 function pickIdxByWeights(freq){ const tot=freq.reduce((s,v)=>s+v,0); let rnd=randInt(1,tot); for(let i=0;i<freq.length;i++){ if(rnd<=freq[i]) return i; rnd-=freq[i]; } return freq.length-1; }
 function cleanCell(c){ return c.trim().replace(/^["']+|["']+$/g,''); }
 function parseCsvLine(l){ const out=[]; let cell='',inQ=false; for(let i=0;i<l.length;i++){ const ch=l[i]; if(ch==='"'){ if(inQ&&l[i+1]==='"'){cell+='"';i++;} else inQ=!inQ;} else if(ch===','&&!inQ){ out.push(cell); cell=''; } else cell+=ch; } out.push(cell); return out; }

--- a/maxmemorizer.html
+++ b/maxmemorizer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <title>Sentence Reconstruction Game</title>
@@ -226,11 +227,6 @@
   /********************************************************************
    * HELPER: Return a cryptographically secure random number [0..1)
    ********************************************************************/
-  function getSecureRandomNumber() {
-    const array = new Uint32Array(1);
-    window.crypto.getRandomValues(array);
-    return array[0] / (0xFFFFFFFF + 1);
-  }
 
   /**
    * Build all front/back permutations for a single record text

--- a/mental-games-2025.html
+++ b/mental-games-2025.html
@@ -13,7 +13,7 @@
                 "https://sktoushi.github.io/stash-utils/clairvoyance-2025.html"
             ];
             
-            const randomUrl = urls[Math.floor(Math.random() * urls.length)];
+            const randomUrl = urls[Math.floor(getSecureRandomNumber() * urls.length)];
             window.location.href = randomUrl;
         });
     </script>

--- a/mental-math-2025.html
+++ b/mental-math-2025.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8">
   <title>Random Math Practice</title>
 
@@ -215,11 +216,6 @@
     /*******************************************************
      * 1) Secure RNG
      *******************************************************/
-    function getSecureRandomNumber() {
-      const array = new Uint32Array(1);
-      window.crypto.getRandomValues(array);
-      return array[0] / (0xffffffff + 1);
-    }
 
     /*******************************************************
      * 2) Pantone Colors (fetch from pantone-colors.json)

--- a/mental-math.html
+++ b/mental-math.html
@@ -56,7 +56,7 @@
         function getRandomLetters(numLetters) {
             const letters = [];
             for (let i = 0; i < numLetters; i++) {
-                const randomCharCode = Math.floor(Math.random() * 26) + 97; // a = 97, z = 122
+                const randomCharCode = Math.floor(getSecureRandomNumber() * 26) + 97; // a = 97, z = 122
                 letters.push(String.fromCharCode(randomCharCode));
             }
             return letters;
@@ -78,7 +78,7 @@
 
             if (!isNaN(maxLetters) && maxLetters >= 2) {
                 // Random number between 2 and maxLetters
-                const numLetters = Math.floor(Math.random() * (maxLetters - 2 + 1)) + 2;
+                const numLetters = Math.floor(getSecureRandomNumber() * (maxLetters - 2 + 1)) + 2;
                 const randomLetters = getRandomLetters(numLetters);
                 // Display the letters in the webpage
                 lettersElement.textContent = randomLetters.join(' + ');

--- a/mit-kanji-random.html
+++ b/mit-kanji-random.html
@@ -40,7 +40,7 @@
             ];
 
             // Randomly choose a URL
-            var randomIndex = Math.floor(Math.random() * urls.length);
+            var randomIndex = Math.floor(getSecureRandomNumber() * urls.length);
             var randomUrl = urls[randomIndex];
 
             // Redirect to the chosen URL

--- a/mixer/mixer.html
+++ b/mixer/mixer.html
@@ -262,7 +262,7 @@
             var originalSentence = sentence.trim();
 
             // Generate random difficulty between 0 and 100
-            var difficulty = Math.floor(Math.random() * 101);
+            var difficulty = Math.floor(getSecureRandomNumber() * 101);
 
             // Jumble the sentence with the difficulty
             var jumbledSentence = jumbleSentence(originalSentence, difficulty);
@@ -396,8 +396,8 @@
         var shuffledIndices = wordIndices.slice();
         if (difficulty > 0) {
             for (var i = shuffledIndices.length - 1; i > 0; i--) {
-                if (Math.random() < (difficulty / 100)) {
-                    var j = Math.floor(Math.random() * (i + 1));
+                if (getSecureRandomNumber() < (difficulty / 100)) {
+                    var j = Math.floor(getSecureRandomNumber() * (i + 1));
                     var temp = shuffledIndices[i];
                     shuffledIndices[i] = shuffledIndices[j];
                     shuffledIndices[j] = temp;
@@ -423,7 +423,7 @@
 
     // Function to get a random hex color
     function getRandomHexColor() {
-        var hex = '#' + Math.floor(Math.random() * 16777215).toString(16);
+        var hex = '#' + Math.floor(getSecureRandomNumber() * 16777215).toString(16);
         return hex.padEnd(7, '0'); // Ensure the hex code is 7 characters
     }
 
@@ -653,7 +653,7 @@
         // Get three random words
         var selectedWords = [];
         for (var i = 0; i < 3 && meaningfulWords.length > 0; i++) {
-            var index = Math.floor(Math.random() * meaningfulWords.length);
+            var index = Math.floor(getSecureRandomNumber() * meaningfulWords.length);
             selectedWords.push(meaningfulWords.splice(index, 1)[0]);
         }
 

--- a/old-mixer.html
+++ b/old-mixer.html
@@ -181,8 +181,8 @@ function jumbleSentence(sentence, difficulty) {
     var shuffledIndices = wordIndices.slice();
     if (difficulty > 0) {
         for (var i = shuffledIndices.length - 1; i > 0; i--) {
-            if (Math.random() < (difficulty / 100)) {
-                var j = Math.floor(Math.random() * (i + 1));
+            if (getSecureRandomNumber() < (difficulty / 100)) {
+                var j = Math.floor(getSecureRandomNumber() * (i + 1));
                 var temp = shuffledIndices[i];
                 shuffledIndices[i] = shuffledIndices[j];
                 shuffledIndices[j] = temp;

--- a/pmbucket.html
+++ b/pmbucket.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker with Customizable Settings</title>
     <!-- Bootstrap CSS -->
@@ -44,11 +45,6 @@
         let urlPrefix = ''; // URL Prefix
         let urlSuffix = ''; // URL Suffix
 
-        function getSecureRandomNumber() {
-          const array = new Uint32Array(1);
-          window.crypto.getRandomValues(array);
-          return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Simplified list of URL bodies and frequencies
         // let initialFiles = [

--- a/projectManagement-ralloc.html
+++ b/projectManagement-ralloc.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Ralloc</title>
     <!-- Include Bootstrap CSS -->
@@ -237,11 +238,6 @@
     <!-- Custom JavaScript -->
     <script>
 	
-		function getSecureRandomNumber() {
-		  const array = new Uint32Array(1);
-		  window.crypto.getRandomValues(array);
-		  return array[0] / (0xFFFFFFFF + 1);
-		}
 	
         $(document).ready(function() {
             // Global variables

--- a/ralloc.html
+++ b/ralloc.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Ralloc</title>
     <!-- Include Bootstrap CSS -->
@@ -342,11 +343,6 @@
     <!-- Custom JavaScript -->
     <script>
 
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         $(document).ready(function() {
             // Initialize tooltips

--- a/ralloc2025.html
+++ b/ralloc2025.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Ralloc</title>
     <!-- Include Bootstrap CSS -->
@@ -342,11 +343,6 @@
     <!-- Custom JavaScript -->
     <script>
 
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         $(document).ready(function() {
             // Initialize tooltips

--- a/random_aristotle_verbatim.html
+++ b/random_aristotle_verbatim.html
@@ -8,7 +8,7 @@
       // Range is 030–200 inclusive
       var min = 30;
       var max = 200;
-      var num = Math.floor(Math.random() * (max - min + 1)) + min;
+      var num = Math.floor(getSecureRandomNumber() * (max - min + 1)) + min;
       var padded = ('000' + num).slice(-3);   // zero‑pad to 3 digits
 
       // Build the verbatim GitHub URL (non‑raw, points to the blob page)

--- a/redirect0915-inhouse1.html
+++ b/redirect0915-inhouse1.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="config.js"></script>
@@ -638,11 +639,6 @@ var links2 = [
 	"https://sktoushi.github.io/ref2409/viewer.html?&fileName=240924-notes-1-4.pdf&startIdx=1&endIdx=4"
 ];
 
-function getSecureRandomNumber() {
-    const array = new Uint32Array(1);
-    window.crypto.getRandomValues(array);
-    return array[0] / (0xFFFFFFFF + 1);
-}
 
 // Optimized shuffleArray function to use less memory
 function shuffleArray(array) {

--- a/redirect0915-percentile-slicer.html
+++ b/redirect0915-percentile-slicer.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+    <script src="common/random-utils.js"></script>
     <title>Redirecting...</title>
     <script type="text/javascript">
         (function(){
@@ -13,11 +14,6 @@
                     .catch(error => console.error('Error:', error));
             }
 
-            function getSecureRandomNumber() {
-                const array = new Uint32Array(1);
-                window.crypto.getRandomValues(array);
-                return array[0] / (0xFFFFFFFF + 1);
-            }
 
             // Linear Congruential Generator
             function LCG(seed) {

--- a/redirect0915-resource-allocator.html
+++ b/redirect0915-resource-allocator.html
@@ -1,14 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="common/random-utils.js"></script>
     <title>Redirecting...</title>
     <script type="text/javascript">
         
-        function getSecureRandomNumber() {
-          const array = new Uint32Array(1);
-          window.crypto.getRandomValues(array);
-          return array[0] / (0xFFFFFFFF + 1);
-        }
         
         function parseUrlParams() {
             var params = {};

--- a/redirect0915-yearly.html
+++ b/redirect0915-yearly.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="config.js"></script>
@@ -28,11 +29,6 @@ function updateCounter() {
 /**
  * Returns a float in [0,1).
  */
-function getSecureRandomNumber() {
-  const array = new Uint32Array(1);
-  window.crypto.getRandomValues(array);
-  return array[0] / (0xFFFFFFFF + 1);
-}
 
 /**
  * Weighted picking given an array of numeric weights.

--- a/repository-issue-randomizer-old.html
+++ b/repository-issue-randomizer-old.html
@@ -1,16 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GitHub Issue Randomizer</title>
     <script>
 
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         function getURLParams() {
             const params = new URLSearchParams(window.location.search);

--- a/repository-issue-randomizer.html
+++ b/repository-issue-randomizer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>GitHub Issue Randomizer</title>
@@ -28,11 +29,6 @@
       }
     }
 
-    function getSecureRandomNumber() {
-      const array = new Uint32Array(1);
-      window.crypto.getRandomValues(array);
-      return array[0] / (0xFFFFFFFF + 1);
-    }
 
     function getURLParams() {
       const params = new URLSearchParams(window.location.search);

--- a/skyway-250613.html
+++ b/skyway-250613.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8">
   <title>Random CSV Redirect (Weighted + Nested CSV + Proper Quoted CSV Parsing)</title>
 </head>
@@ -20,11 +21,6 @@ async function loadConfig() {
 }
 
 /* ──────────────── RANDOM HELPERS ──────────────── */
-function getSecureRandomNumber() {
-  const a = new Uint32Array(1);
-  crypto.getRandomValues(a);
-  return a[0] / (0xFFFFFFFF + 1);
-}
 
 /* ──────────────── CSV UTILITIES ──────────────── */
 function cleanCell(c) { return c.trim().replace(/^["']+|["']+$/g, ''); }

--- a/skyway-recent5percent.html
+++ b/skyway-recent5percent.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8">
   <title>Skyway Recent 5% Randomizer</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -20,7 +21,7 @@ async function loadConfig(){
       if(Array.isArray(raw.patches) && raw.patches.length){
         const weights = raw.patches.map(p=>Number(p.distributionWeight)||1);
         const tot = weights.reduce((a,b)=>a+b,0);
-        let rnd = Math.random()*tot;
+        let rnd = getSecureRandomNumber()*tot;
         for(let i=0;i<raw.patches.length;i++){
           if(rnd < weights[i]){ patch = {...raw.patches[i]}; break; }
           rnd -= weights[i];
@@ -32,8 +33,6 @@ async function loadConfig(){
   }catch(e){ console.error('Config load failed:',e); }
   return configValues;
 }
-function getSecureRandomNumber(){ const a=new Uint32Array(1); crypto.getRandomValues(a); return a[0]/(0xFFFFFFFF+1); }
-function randInt(min,max){ return Math.floor(getSecureRandomNumber()*(max-min+1))+min; }
 function cleanCell(c){ return c.trim().replace(/^["']+|["']+$/g,''); }
 function parseCsvLine(l){ const out=[]; let cell='',inQ=false; for(let i=0;i<l.length;i++){ const ch=l[i]; if(ch==='"'){ if(inQ && l[i+1]==='"'){ cell+='"'; i++; } else inQ=!inQ; } else if(ch===',' && !inQ){ out.push(cell); cell=''; } else cell+=ch; } out.push(cell); return out; }
 function tryEvalExpr(str){ if(!/^[0-9+\-*/ ().]+$/.test(str)) return str; try{ const v=Function('"use strict";return ('+str+')')(); return Number.isFinite(v)?String(v):str; }catch{ return str; }}

--- a/skyway-replica-202506.html
+++ b/skyway-replica-202506.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8">
   <title>Random CSV Redirect (Weighted + Nested + Variables)</title>
 </head>
@@ -18,7 +19,7 @@ async function loadConfig() {
       if (Array.isArray(raw.patches) && raw.patches.length) {
         const weights = raw.patches.map(p => Number(p.distributionWeight) || 1);
         const tot = weights.reduce((a, b) => a + b, 0);
-        let rnd = Math.random() * tot;
+        let rnd = getSecureRandomNumber() * tot;
         for (let i = 0; i < raw.patches.length; i++) {
           if (rnd < weights[i]) { patch = { ...raw.patches[i] }; break; }
           rnd -= weights[i];
@@ -36,11 +37,6 @@ async function loadConfig() {
 /*  0.  SECURE RNG                                                    */
 /* ------------------------------------------------------------------ */
 /** Returns a cryptographically-secure random number in [0, 1). */
-function getSecureRandomNumber() {
-  const array = new Uint32Array(1);
-  window.crypto.getRandomValues(array);
-  return array[0] / (0xFFFFFFFF + 1);
-}
 
 /* ------------------------------------------------------------------ */
 /*  1.  STRING HELPERS                                                */

--- a/skyway-replica-250613.html
+++ b/skyway-replica-250613.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8">
   <title>skyway.html – Hierarchical Multi-Mode Randomizer (multi-distribution)</title>
 </head>
@@ -90,7 +91,7 @@ async function loadConfig() {
       if (Array.isArray(raw.patches) && raw.patches.length) {
         const weights = raw.patches.map(p => Number(p.distributionWeight) || 1);
         const tot = weights.reduce((a, b) => a + b, 0);
-        let rnd = Math.random() * tot;
+        let rnd = getSecureRandomNumber() * tot;
         for (let i = 0; i < raw.patches.length; i++) {
           if (rnd < weights[i]) { patch = { ...raw.patches[i] }; break; }
           rnd -= weights[i];
@@ -104,11 +105,6 @@ async function loadConfig() {
 }
 
 /* ──────────────── RANDOM HELPERS ──────────────── */
-function getSecureRandomNumber() {
-  const a = new Uint32Array(1);
-  crypto.getRandomValues(a);
-  return a[0] / (0xFFFFFFFF + 1);
-}
 function randInt(min, max) { return Math.floor(getSecureRandomNumber()*(max-min+1))+min; }
 function pickIdxByWeights(freq) {
   const tot=freq.reduce((s,v)=>s+v,0);

--- a/skyway.html
+++ b/skyway.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8">
   <title>skyway.html – Hierarchical Multi-Mode Randomizer (multi-distribution)</title>
 </head>
@@ -90,7 +91,7 @@ async function loadConfig() {
       if (Array.isArray(raw.patches) && raw.patches.length) {
         const weights = raw.patches.map(p => Number(p.distributionWeight) || 1);
         const tot = weights.reduce((a, b) => a + b, 0);
-        let rnd = Math.random() * tot;
+        let rnd = getSecureRandomNumber() * tot;
         for (let i = 0; i < raw.patches.length; i++) {
           if (rnd < weights[i]) { patch = { ...raw.patches[i] }; break; }
           rnd -= weights[i];
@@ -104,11 +105,6 @@ async function loadConfig() {
 }
 
 /* ──────────────── RANDOM HELPERS ──────────────── */
-function getSecureRandomNumber() {
-  const a = new Uint32Array(1);
-  crypto.getRandomValues(a);
-  return a[0] / (0xFFFFFFFF + 1);
-}
 function randInt(min, max) { return Math.floor(getSecureRandomNumber()*(max-min+1))+min; }
 function pickIdxByWeights(freq) {
   const tot=freq.reduce((s,v)=>s+v,0);

--- a/skyway1.html
+++ b/skyway1.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8">
   <title>Random CSV Redirect (Weighted + Nested + Variables)</title>
 </head>
@@ -18,7 +19,7 @@ async function loadConfig() {
       if (Array.isArray(raw.patches) && raw.patches.length) {
         const weights = raw.patches.map(p => Number(p.distributionWeight) || 1);
         const tot = weights.reduce((a, b) => a + b, 0);
-        let rnd = Math.random() * tot;
+        let rnd = getSecureRandomNumber() * tot;
         for (let i = 0; i < raw.patches.length; i++) {
           if (rnd < weights[i]) { patch = { ...raw.patches[i] }; break; }
           rnd -= weights[i];
@@ -36,11 +37,6 @@ async function loadConfig() {
 /*  0.  SECURE RNG                                                    */
 /* ------------------------------------------------------------------ */
 /** Returns a cryptographically-secure random number in [0, 1). */
-function getSecureRandomNumber() {
-  const array = new Uint32Array(1);
-  window.crypto.getRandomValues(array);
-  return array[0] / (0xFFFFFFFF + 1);
-}
 
 /* ------------------------------------------------------------------ */
 /*  1.  STRING HELPERS                                                */

--- a/skyway2.html
+++ b/skyway2.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
   <meta charset="UTF-8">
   <title>Random CSV Redirect (Weighted + Nested + Variables)</title>
 </head>
@@ -18,7 +19,7 @@ async function loadConfig() {
       if (Array.isArray(raw.patches) && raw.patches.length) {
         const weights = raw.patches.map(p => Number(p.distributionWeight) || 1);
         const tot = weights.reduce((a, b) => a + b, 0);
-        let rnd = Math.random() * tot;
+        let rnd = getSecureRandomNumber() * tot;
         for (let i = 0; i < raw.patches.length; i++) {
           if (rnd < weights[i]) { patch = { ...raw.patches[i] }; break; }
           rnd -= weights[i];
@@ -36,11 +37,6 @@ async function loadConfig() {
 /*  0.  SECURE RNG                                                    */
 /* ------------------------------------------------------------------ */
 /** Returns a cryptographically-secure random number in [0, 1). */
-function getSecureRandomNumber() {
-  const array = new Uint32Array(1);
-  window.crypto.getRandomValues(array);
-  return array[0] / (0xFFFFFFFF + 1);
-}
 
 /* ------------------------------------------------------------------ */
 /*  1.  STRING HELPERS                                                */

--- a/stash-randomizer-csv-generator.html
+++ b/stash-randomizer-csv-generator.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Redirect</title>
     <!-- Minimal styling for clarity; no Bootstrap needed -->
@@ -30,11 +31,6 @@
         /************************************************************
          * PART 1: SHARED HELPER FUNCTIONS (CRYPTO RNG, Weighted picks, etc.)
          ************************************************************/
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Weighted picking for an array of items, using parallel array of numeric weights.
         function weightedRandomPick(items, weights) {

--- a/stash-randomizer.html
+++ b/stash-randomizer.html
@@ -1,15 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Redirect</title>
     <script>
-        // Secure random number generator function
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Weighted random pick function
         function weightedRandomPick(items, weights) {

--- a/stash-randomizer1.html
+++ b/stash-randomizer1.html
@@ -1,15 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Redirect</title>
     <script>
-        // Secure random number generator function
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Weighted random pick function
         function weightedRandomPick(items, weights) {

--- a/stash-randomizer2.html
+++ b/stash-randomizer2.html
@@ -1,15 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Redirect</title>
     <script>
-        // Secure random number generator function
-        function getSecureRandomNumber() {
-            const array = new Uint32Array(1);
-            window.crypto.getRandomValues(array);
-            return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Weighted random pick with simple recency bias
         function weightedRandomPickWithRecency(items, weights) {

--- a/stash2-bucket.html
+++ b/stash2-bucket.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker with Customizable Settings</title>
     <!-- Bootstrap CSS -->
@@ -44,11 +45,6 @@
         let urlPrefix = ''; // URL Prefix
         let urlSuffix = ''; // URL Suffix
 
-        function getSecureRandomNumber() {
-          const array = new Uint32Array(1);
-          window.crypto.getRandomValues(array);
-          return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Simplified list of URL bodies and frequencies
         // let initialFiles = [

--- a/subliminal-psychology-bucket.html
+++ b/subliminal-psychology-bucket.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker with Customizable Settings</title>
     <!-- Bootstrap CSS -->
@@ -44,11 +45,6 @@
         let urlPrefix = ''; // URL Prefix
         let urlSuffix = ''; // URL Suffix
 
-        function getSecureRandomNumber() {
-          const array = new Uint32Array(1);
-          window.crypto.getRandomValues(array);
-          return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Simplified list of URL bodies and frequencies
         // let initialFiles = [

--- a/sutashu-bucket.html
+++ b/sutashu-bucket.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <title>Random URL Picker with Customizable Settings</title>
     <!-- Bootstrap CSS -->
@@ -44,11 +45,6 @@
         let urlPrefix = ''; // URL Prefix
         let urlSuffix = ''; // URL Suffix
 
-        function getSecureRandomNumber() {
-          const array = new Uint32Array(1);
-          window.crypto.getRandomValues(array);
-          return array[0] / (0xFFFFFFFF + 1);
-        }
 
         // Simplified list of URL bodies and frequencies
         // let initialFiles = [

--- a/ticket/cashAccount.js
+++ b/ticket/cashAccount.js
@@ -229,7 +229,7 @@ function createTicket(date, amount) {
 }
 
 function generateSerial() {
-    return 'SN' + (new Date().getFullYear() % 100) + "-" + Math.random().toString(36).substr(2, 9).toUpperCase();
+    return 'SN' + (new Date().getFullYear() % 100) + "-" + getSecureRandomNumber().toString(36).substr(2, 9).toUpperCase();
 }
 
 function unallocateCash(index) {

--- a/ticket/goals.js
+++ b/ticket/goals.js
@@ -300,7 +300,7 @@ function showGoalTicketsModal(goal) {
 
 // Function to generate a random hex color (same as in tickets.js)
 function generateRandomHexColor() {
-    let color = '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
+    let color = '#' + Math.floor(getSecureRandomNumber()*16777215).toString(16).padStart(6, '0');
     return color.toUpperCase();
 }
 

--- a/ticket/tickets.js
+++ b/ticket/tickets.js
@@ -2,7 +2,7 @@
 
 // Function to generate a random hex color
 function generateRandomHexColor() {
-    let color = '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
+    let color = '#' + Math.floor(getSecureRandomNumber()*16777215).toString(16).padStart(6, '0');
     return color.toUpperCase();
 }
 

--- a/traverse0915-pdf.html
+++ b/traverse0915-pdf.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="common/random-utils.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="config.js"></script>
@@ -9,11 +10,6 @@
 
 <script>
 
-function getSecureRandomNumber() {
-  const array = new Uint32Array(1);
-  window.crypto.getRandomValues(array);
-  return array[0] / (0xFFFFFFFF + 1);
-}
 
 function randomIntFromInterval(min, max) { 
     return Math.floor(getSecureRandomNumber() * (Number(max) - Number(min) + 1)) + Number(min);

--- a/viewer.html
+++ b/viewer.html
@@ -31,7 +31,7 @@
         }
 
         function getRandomPage(startIdx, endIdx) {
-            return Math.floor(Math.random() * (endIdx - startIdx + 1)) + startIdx;
+            return Math.floor(getSecureRandomNumber() * (endIdx - startIdx + 1)) + startIdx;
         }
 
         function displayPdf() {

--- a/watcher.html
+++ b/watcher.html
@@ -104,7 +104,7 @@ function generateNotificationTimes(numRewinds, episodeDuration) {
 
     if (segmentEnd <= segmentStart) continue;
 
-    const randomTimeInSegment = segmentStart + Math.random() * (segmentEnd - segmentStart);
+    const randomTimeInSegment = segmentStart + getSecureRandomNumber() * (segmentEnd - segmentStart);
     times.push(randomTimeInSegment);
   }
 

--- a/wut-do.html
+++ b/wut-do.html
@@ -80,7 +80,7 @@
         // Function to pick a random activity based on weights
         function getRandomActivity(activities) {
             let totalWeight = Object.values(activities).reduce((sum, w) => sum + w, 0);
-            let random = Math.random() * totalWeight;
+            let random = getSecureRandomNumber() * totalWeight;
             let cumulativeWeight = 0;
 
             for (let activity in activities) {


### PR DESCRIPTION
## Summary
- use `getSecureRandomNumber()` everywhere instead of `Math.random`
- centralize the secure RNG helper in `common/random-utils.js`
- import that helper on HTML pages

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68567fd8c6e08320a791eaa22df89500