### PR TITLE
Fix injection weighting

### DIFF
--- a/stash-randomizer.html
+++ b/stash-randomizer.html
@@ -63,22 +63,25 @@
                 .map(str => Number(str))
                 .filter(num => !isNaN(num));
 
-            // Determine base weights for main items
-            let baseWeights;
-            if (allocationArray.length === userRepoArray.length && allocationArray.length > 0 && allocationArray.every(w => w >= 0)) {
-                baseWeights = allocationArray;
-            } else {
-                baseWeights = new Array(userRepoArray.length).fill(1);
-            }
+            // Determine the size of each repo range so injections can be
+            // distributed relative to the total picking pool
+            const repoSizes = userRepoArray.map(item => {
+                const parts = item.split('_');
+                const s = Number(parts[2]);
+                const e = Number(parts[3]);
+                return Math.max(1, (isNaN(e) || isNaN(s)) ? 1 : (e - s + 1));
+            });
 
-            // Balance injection weights if they outweigh the base pool
-            const baseTotal = baseWeights.reduce((a, b) => a + b, 0);
-            const injTotal = injectionWeights.reduce((a, b) => a + b, 0);
-            let scaledInj = injectionWeights.slice();
-            if (injTotal > baseTotal && baseTotal > 0) {
-                const factor = baseTotal / injTotal;
-                scaledInj = injectionWeights.map(w => w * factor);
-            }
+            const validAlloc = allocationArray.length === userRepoArray.length &&
+                               allocationArray.length > 0 &&
+                               allocationArray.every(w => w >= 0);
+
+            const baseWeights = repoSizes.map((sz, i) =>
+                sz * (validAlloc ? allocationArray[i] : 1)
+            );
+
+            // Injection weights represent actual record counts; no scaling
+            const scaledInj = injectionWeights.slice();
 
             // Append injection items and weights
             const combinedItems = userRepoArray.concat(injectionItems);

--- a/stash-randomizer1.html
+++ b/stash-randomizer1.html
@@ -63,22 +63,25 @@
                 .map(str => Number(str))
                 .filter(num => !isNaN(num));
 
-            // Determine base weights for main items
-            let baseWeights;
-            if (allocationArray.length === userRepoArray.length && allocationArray.length > 0 && allocationArray.every(w => w >= 0)) {
-                baseWeights = allocationArray;
-            } else {
-                baseWeights = new Array(userRepoArray.length).fill(1);
-            }
+            // Determine the size of each repo range so injections can be
+            // distributed relative to the total picking pool
+            const repoSizes = userRepoArray.map(item => {
+                const parts = item.split('_');
+                const s = Number(parts[2]);
+                const e = Number(parts[3]);
+                return Math.max(1, (isNaN(e) || isNaN(s)) ? 1 : (e - s + 1));
+            });
 
-            // Balance injection weights if they outweigh the base pool
-            const baseTotal = baseWeights.reduce((a, b) => a + b, 0);
-            const injTotal = injectionWeights.reduce((a, b) => a + b, 0);
-            let scaledInj = injectionWeights.slice();
-            if (injTotal > baseTotal && baseTotal > 0) {
-                const factor = baseTotal / injTotal;
-                scaledInj = injectionWeights.map(w => w * factor);
-            }
+            const validAlloc = allocationArray.length === userRepoArray.length &&
+                               allocationArray.length > 0 &&
+                               allocationArray.every(w => w >= 0);
+
+            const baseWeights = repoSizes.map((sz, i) =>
+                sz * (validAlloc ? allocationArray[i] : 1)
+            );
+
+            // Injection weights represent actual record counts; no scaling
+            const scaledInj = injectionWeights.slice();
 
             // Append injection items and weights
             const combinedItems = userRepoArray.concat(injectionItems);

--- a/stash-randomizer2.html
+++ b/stash-randomizer2.html
@@ -77,22 +77,25 @@
                 .map(str => Number(str))
                 .filter(num => !isNaN(num));
 
-            // Determine base weights for main items
-            let baseWeights;
-            if (allocationArray.length === userRepoArray.length && allocationArray.length > 0 && allocationArray.every(w => w >= 0)) {
-                baseWeights = allocationArray;
-            } else {
-                baseWeights = new Array(userRepoArray.length).fill(1);
-            }
+            // Determine the size of each repo range so injections can be
+            // distributed relative to the total picking pool
+            const repoSizes = userRepoArray.map(item => {
+                const parts = item.split('_');
+                const s = Number(parts[2]);
+                const e = Number(parts[3]);
+                return Math.max(1, (isNaN(e) || isNaN(s)) ? 1 : (e - s + 1));
+            });
 
-            // Balance injection weights if they outweigh the base pool
-            const baseTotal = baseWeights.reduce((a, b) => a + b, 0);
-            const injTotal = injectionWeights.reduce((a, b) => a + b, 0);
-            let scaledInj = injectionWeights.slice();
-            if (injTotal > baseTotal && baseTotal > 0) {
-                const factor = baseTotal / injTotal;
-                scaledInj = injectionWeights.map(w => w * factor);
-            }
+            const validAlloc = allocationArray.length === userRepoArray.length &&
+                               allocationArray.length > 0 &&
+                               allocationArray.every(w => w >= 0);
+
+            const baseWeights = repoSizes.map((sz, i) =>
+                sz * (validAlloc ? allocationArray[i] : 1)
+            );
+
+            // Injection weights represent actual record counts; no scaling
+            const scaledInj = injectionWeights.slice();
 
             // Append injection items and weights
             const combinedItems = userRepoArray.concat(injectionItems);

--- a/stash-randomizer3.html
+++ b/stash-randomizer3.html
@@ -118,20 +118,18 @@ function updateSRS(item) {
   let alloc = (qs.get('allocation') || '')
       .split(',').map(Number).filter(n => !isNaN(n));
 
-  let baseW;
-  if (alloc.length === pairs.length && alloc.length > 0 && alloc.every(n => n >= 0)) {
-    baseW = alloc;
-  } else {
-    baseW = new Array(pairs.length).fill(1);
-  }
+  const repoSizes = pairs.map(it => {
+    const [,,,s,e] = it.split('_');
+    const start = Number(s);
+    const end   = Number(e);
+    return Math.max(1, (isNaN(start) || isNaN(end)) ? 1 : (end - start + 1));
+  });
 
-  const baseTotal = baseW.reduce((a, b) => a + b, 0);
-  const injTotal = injectionWeights.reduce((a, b) => a + b, 0);
-  let scaledInj = injectionWeights.slice();
-  if (injTotal > baseTotal && baseTotal > 0) {
-    const factor = baseTotal / injTotal;
-    scaledInj = injectionWeights.map(w => w * factor);
-  }
+  const validAlloc = alloc.length === pairs.length && alloc.length > 0 && alloc.every(n => n >= 0);
+
+  const baseW = repoSizes.map((sz, i) => sz * (validAlloc ? alloc[i] : 1));
+
+  const scaledInj = injectionWeights.slice();
 
   const combinedItems = pairs.concat(injectionItems);
   const combinedWeights = baseW.concat(scaledInj);

--- a/stash-randomizer4.html
+++ b/stash-randomizer4.html
@@ -113,20 +113,18 @@ async function updateAfterPick(db, id, oldRec) {
   let pairs  = (qs.get('usernameRepoList') || '').split(',').filter(Boolean);
   let alloc  = (qs.get('allocation')       || '').split(',').map(Number);
 
-  let baseW;
-  if (alloc.length === pairs.length && alloc.length > 0 && alloc.every(n => n >= 0)) {
-    baseW = alloc;
-  } else {
-    baseW = Array(pairs.length).fill(1);
-  }
+  const repoSizes = pairs.map(p => {
+    const [,,,s,e] = p.split('_');
+    const start = Number(s);
+    const end   = Number(e);
+    return Math.max(1, (isNaN(start) || isNaN(end)) ? 1 : (end - start + 1));
+  });
 
-  const baseTotal = baseW.reduce((a, b) => a + b, 0);
-  const injTotal = injectionWeights.reduce((a, b) => a + b, 0);
-  let scaledInj = injectionWeights.slice();
-  if (injTotal > baseTotal && baseTotal > 0) {
-    const factor = baseTotal / injTotal;
-    scaledInj = injectionWeights.map(w => w * factor);
-  }
+  const validAlloc = alloc.length === pairs.length && alloc.length > 0 && alloc.every(n => n >= 0);
+
+  const baseW = repoSizes.map((sz, i) => sz * (validAlloc ? alloc[i] : 1));
+
+  const scaledInj = injectionWeights.slice();
 
   const combinedItems = pairs.concat(injectionItems);
   const combinedWeights = baseW.concat(scaledInj);

--- a/stash-randomizer5.html
+++ b/stash-randomizer5.html
@@ -116,20 +116,18 @@ async function commit(db, id, rec, success) {
   const modes  = (qs.get('modes')            || '').split(',').filter(Boolean);
   let pairs  = (qs.get('usernameRepoList') || '').split(',').filter(Boolean);
   let alloc  = (qs.get('allocation')       || '').split(',').map(Number);
-  let baseW;
-  if (alloc.length === pairs.length && alloc.length > 0 && alloc.every(n => n >= 0)) {
-    baseW = alloc;
-  } else {
-    baseW = Array(pairs.length).fill(1);
-  }
+  const repoSizes = pairs.map(p => {
+    const [,,,s,e] = p.split('_');
+    const start = Number(s);
+    const end   = Number(e);
+    return Math.max(1, (isNaN(start) || isNaN(end)) ? 1 : (end - start + 1));
+  });
 
-  const baseTotal = baseW.reduce((a, b) => a + b, 0);
-  const injTotal = injectionWeights.reduce((a, b) => a + b, 0);
-  let scaledInj = injectionWeights.slice();
-  if (injTotal > baseTotal && baseTotal > 0) {
-    const factor = baseTotal / injTotal;
-    scaledInj = injectionWeights.map(w => w * factor);
-  }
+  const validAlloc = alloc.length === pairs.length && alloc.length > 0 && alloc.every(n => n >= 0);
+
+  const baseW = repoSizes.map((sz, i) => sz * (validAlloc ? alloc[i] : 1));
+
+  const scaledInj = injectionWeights.slice();
 
   const combinedItems = pairs.concat(injectionItems);
   const combinedWeights = baseW.concat(scaledInj);

--- a/stash-randomizer6.html
+++ b/stash-randomizer6.html
@@ -84,17 +84,17 @@ const qs    = new URLSearchParams(location.search);
 const modes = (qs.get('modes')||'').split(',').filter(Boolean);
 let items = (qs.get('usernameRepoList')||'').split(',').filter(Boolean);
 let alloc = (qs.get('allocation')||'').split(',').map(Number);
-let baseW;
-if(alloc.length===items.length && alloc.length>0 && alloc.every(n=>n>=0))
-  baseW = alloc; else baseW = Array(items.length).fill(1);
+const repoSizes=items.map(it=>{
+  const [,,,s,e]=it.split('_');
+  const start=Number(s); const end=Number(e);
+  return Math.max(1,(isNaN(start)||isNaN(end))?1:(end-start+1));
+});
 
-const baseTotal=baseW.reduce((a,b)=>a+b,0);
-const injTotal=injectionWeights.reduce((a,b)=>a+b,0);
-let scaledInj=injectionWeights.slice();
-if(injTotal>baseTotal && baseTotal>0){
-  const factor=baseTotal/injTotal;
-  scaledInj=injectionWeights.map(w=>w*factor);
-}
+const validAlloc=alloc.length===items.length && alloc.length>0 && alloc.every(n=>n>=0);
+
+const baseW=repoSizes.map((sz,i)=>sz*(validAlloc?alloc[i]:1));
+
+const scaledInj=injectionWeights.slice();
 
 const combinedItems = items.concat(injectionItems);
 const combinedWeights = baseW.concat(scaledInj);


### PR DESCRIPTION
## Summary
- calculate repo range sizes in every stash-randomizer variant
- use repo sizes (and optional allocations) as base weights
- treat injection weights as counts without scaling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856a41844948320ac82db10864a553b