### PR TITLE
Enable GitHub-style dark mode for looptube

### DIFF
--- a/looptube.html
+++ b/looptube.html
@@ -6,11 +6,18 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
-    body { padding:1rem; }
+    body { padding:1rem; background-color:#0d1117; color:#c9d1d9; }
     #player{ width:100%; height:100%; }
+    .form-control{ background-color:#161b22; color:#c9d1d9; border-color:#30363d; }
+    .btn-secondary{ background-color:#21262d; color:#c9d1d9; border-color:#30363d; }
+    .btn-secondary:hover{ background-color:#30363d; color:#c9d1d9; border-color:#30363d; }
+    .btn-primary{ background-color:#238636; border-color:#2ea043; }
+    .btn-primary:hover{ background-color:#2ea043; border-color:#238636; }
+    .btn-success{ background-color:#2da44e; border-color:#2c974b; }
+    .btn-success:hover{ background-color:#2c974b; border-color:#2da44e; }
   </style>
 </head>
-<body class="text-center">
+<body class="text-center" data-bs-theme="dark">
 <div class="container">
   <div class="input-group mb-3">
     <input id="urlInput" type="text" class="form-control" placeholder="YouTube URL">


### PR DESCRIPTION
## Summary
- tweak looptube.html styles to mimic GitHub dark colors
- set Bootstrap theme to dark

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856a96fb0448320a0484c60e2c77e48