### PR TITLE
Fix randInt error in recent5 page

### DIFF
--- a/common/random-utils.js
+++ b/common/random-utils.js
@@ -4,6 +4,10 @@ function getSecureRandomNumber() {
   return array[0] / (0xFFFFFFFF + 1);
 }
 
+function randInt(min, max) {
+  return Math.floor(getSecureRandomNumber() * (max - min + 1)) + min;
+}
+
 function getRandomIndexByFrequency(frequencyArray) {
     // Calculate the cumulative sum of frequencies
     const cumulativeSum = [];


### PR DESCRIPTION
## Summary
- add global `randInt` helper to `random-utils.js`

## Testing
- `node -e "const fs=require('fs');let html=fs.readFileSync('skyway-recent5percent.html','utf8');console.log(html.includes('randInt('));"`

------
https://chatgpt.com/codex/tasks/task_e_6856b19bd2a88320b8437b67299cc0b2