### PR TITLE
Add TGDS Randomizer

### DIFF
--- a/tgds-randomizer.html
+++ b/tgds-randomizer.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>TGDS Randomizer</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<script src="common/random-utils.js"></script>
+<style>
+body{padding:20px;}
+</style>
+</head>
+<body>
+<div class="container">
+<h1 class="mb-3">TGDS Randomizer</h1>
+<p>Review pages: <span id="reviewCount">0</span> | New pages: <span id="newCount">0</span></p>
+</div>
+<script>
+const DB_NAME='tgdsRandomizerDB';
+const STORE='state';
+const VERSION=1;
+let db=null,state=null;
+function openDB(){
+  return new Promise((res,rej)=>{
+    const r=indexedDB.open(DB_NAME,VERSION);
+    r.onupgradeneeded=e=>{
+      const db=e.target.result;
+      if(!db.objectStoreNames.contains(STORE))
+        db.createObjectStore(STORE,{keyPath:'id'});
+    };
+    r.onerror=()=>rej(r.error);
+    r.onsuccess=()=>res(r.result);
+  });
+}
+function idbGet(key){
+  return new Promise((res,rej)=>{
+    const tx=db.transaction(STORE,'readonly').objectStore(STORE).get(key);
+    tx.onsuccess=()=>res(tx.result?tx.result.data:null);
+    tx.onerror=()=>rej(tx.error);
+  });
+}
+function idbPut(key,val){
+  return new Promise((res,rej)=>{
+    const tx=db.transaction(STORE,'readwrite').objectStore(STORE).put({id:key,data:val});
+    tx.onsuccess=()=>res();
+    tx.onerror=()=>rej(tx.error);
+  });
+}
+async function loadState(){
+  db=await openDB();
+  state=await idbGet('main');
+  if(!state){
+    state={reviewBucket:[],newBucket:[],initiated:false};
+  }
+  if(!state.initiated){
+    for(let i=1;i<=1113;i++) state.newBucket.push(i);
+    state.initiated=true;
+    await saveState();
+  }
+  updateCounts();
+  pick();
+}
+async function saveState(){
+  await idbPut('main',state);
+}
+function pick(){
+  if(!state.reviewBucket.length && !state.newBucket.length){alert('No pages');return;}
+  const useReview=getSecureRandomNumber()<0.33 && state.reviewBucket.length;
+  const bucket=useReview?state.reviewBucket:state.newBucket;
+  if(!bucket.length){
+    const other=useReview?state.newBucket:state.reviewBucket;
+    if(!other.length){alert('No pages');return;}
+    return pickFrom(other,useReview?false:true);
+  }
+  pickFrom(bucket,useReview);
+}
+function pickFrom(bucket,isReview){
+  const idx=Math.floor(getSecureRandomNumber()*bucket.length);
+  const item=bucket[idx];
+  if(!isReview){
+    bucket.splice(idx,1);
+    state.reviewBucket.push(item);
+  }
+  saveState();
+  updateCounts();
+  const url='https://sktoushi.github.io/stash-utils/tdgs.html?page='+item;
+  window.location.href=url;
+}
+function updateCounts(){
+  document.getElementById('reviewCount').textContent=state.reviewBucket.length;
+  document.getElementById('newCount').textContent=state.newBucket.length;
+}
+window.onload=loadState;
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `tgds-randomizer.html` for random TDGS page selection
- implement bucket algorithm with IndexedDB storage
- update to instantly redirect without a draw button

## Testing
- `git status --short`
- `ls | grep package.json`


------
https://chatgpt.com/codex/tasks/task_e_6856fa2e8b088320bbbdd889c3ebc4e1