### PR TITLE
Improve skyway progress and delay

### DIFF
--- a/common/color-utils.js
+++ b/common/color-utils.js
@@ -1,0 +1,25 @@
+async function getRandomColor() {
+    try {
+        const response = await fetch('pantone-colors.json');
+        const pantoneData = await response.json();
+        const { names, values } = pantoneData;
+        if (!names || !values || names.length !== values.length) {
+            throw new Error('Invalid pantone-colors.json format. "names" and "values" must be parallel arrays.');
+        }
+        const randomIndex = Math.floor(getSecureRandomNumber() * names.length);
+        const randomName = names[randomIndex];
+        const randomValue = values[randomIndex];
+        document.body.style.backgroundColor = randomValue;
+        const colorDisplay = document.getElementById('pantoneColorDisplay');
+        if (colorDisplay) {
+            colorDisplay.textContent = `${randomName} (${randomValue})`;
+        }
+        window.lastPantoneColor = randomValue;
+        return randomValue;
+    } catch (error) {
+        console.error('Error fetching pantone-colors.json:', error);
+        document.body.style.backgroundColor = '#ffffff';
+        window.lastPantoneColor = '#ffffff';
+        return '#ffffff';
+    }
+}

--- a/config/values.json
+++ b/config/values.json
@@ -29,6 +29,10 @@
     "theSnackbarEnding": "33",
     "imgStarting": "1",
     "imgEnding": "195",
+    "progressCurrentValueFormula": "publicRepoEnding + stashEnding + stash1p5Ending + stash2Ending + stash3Ending",
+    "progressTargetValueFormula": "18393",
+    "lastUpdated": "2025-06-22T04:20:22+08:00",
+    "progressBasis": "568",
     "dbviewerLinks": {
       "baseURL": "https://sktoushi.github.io/ref2506/dbviewer.html?db=",
       "files": [

--- a/skyway.html
+++ b/skyway.html
@@ -3,10 +3,15 @@
 <head>
     <script src="common/random-utils.js"></script>
     <script src="common/skyway-utils.js"></script>
+    <script src="common/color-utils.js"></script>
   <meta charset="UTF-8">
   <title>skyway.html – Hierarchical Multi-Mode Randomizer (multi-distribution)</title>
 </head>
 <body>
+  <div id="progressContainer" style="position:fixed;top:0;left:0;width:100%;height:5px;background:#ddd;display:none;z-index:9999;">
+    <div id="progressBar" style="height:100%;width:0%;background:#4caf50;"></div>
+  </div>
+  <div id="progressSubtext" style="position:fixed;top:6px;width:100%;text-align:center;font-family:sans-serif;font-size:12px;display:none;z-index:9999;"></div>
 <script>
 /*╔══════════════════════════════════════════╗
   ║  HIERARCHICAL DECISION STACK             ║
@@ -20,6 +25,7 @@
 /* ──────────────── URL PARAM PARSE ──────────────── */
 const urlParams   = new URLSearchParams(location.search);
 const targetCsv   = urlParams.get('target');                         // required
+let lastPantoneColor = '#ffffff';
 
 /* ——— SINGLE distribution=1-2-3-2-1 etc. ——— */
 let   distributionArr = null;
@@ -334,6 +340,53 @@ function pickFromBucket(bucket,isReview){
   return item;
 }
 
+function evalFormula(formula){
+  if(!formula) return NaN;
+  let expr = formula;
+  for(const [k,v] of Object.entries(configValues)){
+    expr = expr.replace(new RegExp('\\b'+k+'\\b','g'), v);
+  }
+  try{ return Function('"use strict";return ('+expr+')')(); }
+  catch{ return NaN; }
+}
+
+async function showProgressAndRedirect(url){
+  await loadConfig();
+  const cur = evalFormula(configValues.progressCurrentValueFormula);
+  const target = evalFormula(configValues.progressTargetValueFormula);
+  const container=document.getElementById('progressContainer');
+  const bar=document.getElementById('progressBar');
+  if(!container||!bar){ location.href=url; return; }
+  container.style.display='block';
+  const steps=60; const duration=2000; let step=0;
+  const inc=(target-cur)/steps; let val=cur;
+  return new Promise(resolve=>{
+    const timer=setInterval(()=>{
+      val += inc; step++;
+      const pct=((val-cur)/(target-cur))*100;
+      bar.style.width=pct+'%';
+      if(step>=steps){
+        clearInterval(timer);
+        const delay=0.5+getSecureRandomNumber()*(5000-0.5);
+        setTimeout(()=>{ location.href=url; resolve(); }, delay);
+      }
+    }, duration/steps);
+  });
+}
+
+function updateVisitCounter(){
+  const key='skywayVisitCount';
+  let count=parseInt(localStorage.getItem(key)||'0',10);
+  count++; localStorage.setItem(key,count);
+  return count;
+}
+
+function getPhilippineNow(){
+  const now=new Date();
+  const utc=now.getTime()+now.getTimezoneOffset()*60000;
+  return new Date(utc+8*3600000);
+}
+
 /* ──────────────── MAIN PROCESSOR ──────────────── */
 async function processRows(rows,depth=0){
   if(depth>2000) return document.body.textContent='Max CSV nesting depth exceeded.';
@@ -348,11 +401,11 @@ async function processRows(rows,depth=0){
   const sel=pickRow(rows);
   const type=sel[0].trim();
   if(type==='link' || type==='injection'){
-    location.href=handleSkywayLink(sel,pickBucketItem);
+    await showProgressAndRedirect(handleSkywayLink(sel,pickBucketItem));
     return;
   }
   if(type==='link-jp'){
-    location.href=handleSkywayLink(sel,pickBucketItem,true);
+    await showProgressAndRedirect(handleSkywayLink(sel,pickBucketItem,true));
     return;
   }
 
@@ -377,6 +430,18 @@ async function processRows(rows,depth=0){
 /* ──────────────── ENTRY ──────────────── */
 window.onload = async ()=>{
   if(!targetCsv){ document.body.textContent='Missing ?target=…'; return; }
+  await getRandomColor();
+  await loadConfig();
+  const count=updateVisitCounter();
+  const sub=document.getElementById('progressSubtext');
+  if(sub && configValues.lastUpdated){
+    const last=new Date(configValues.lastUpdated);
+    const now=getPhilippineNow();
+    const days=Math.max(1,(now-last)/86400000);
+    const avg=(count/days).toFixed(2);
+    sub.textContent=`+${count} since ${configValues.lastUpdated}! average: ${avg}`;
+    sub.style.display='block';
+  }
   await loadBucketState();
   try{ await processRows(await fetchCSV(targetCsv)); }
   catch(e){ document.body.textContent=e.message; }


### PR DESCRIPTION
## Summary
- refresh `lastUpdated` timestamp and keep progress basis in `config/values.json`
- implement a delay before redirect inside `showProgressAndRedirect`
- retain pantone color helper for random background
- keep visit counter and subtext display on `skyway.html`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685710473c7c8320a7232d83102ff37a