### PR TITLE
Fix progress bar formula handling

### DIFF
--- a/skyway.html
+++ b/skyway.html
@@ -107,6 +107,11 @@ async function loadConfig() {
         delete patch.distributionWeight;
       }
       configValues = Object.assign({}, base, patch);
+      for (const [k,v] of Object.entries(configValues)) {
+        if (typeof v === 'string' && /^\d+(?:\.\d+)?$/.test(v)) {
+          configValues[k] = Number(v);
+        }
+      }
     }
   } catch (err) { console.error('Config load failed:', err); }
   return configValues;
@@ -358,6 +363,7 @@ async function showProgressAndRedirect(url){
   const container=document.getElementById('progressContainer');
   const bar=document.getElementById('progressBar');
   if(!container||!bar){ location.href=url; return; }
+  if(isNaN(cur)||isNaN(target)||target<=cur){ location.href=url; return; }
   container.style.display='block';
   const steps=60; const duration=2000; let step=0;
   const inc=(target-cur)/steps; let val=cur;


### PR DESCRIPTION
## Summary
- parse numeric strings from `values.json`
- guard against invalid progress values before showing the progress bar

## Testing
- `node - <<'NODE'
const fs=require('fs');
const values=JSON.parse(fs.readFileSync('config/values.json','utf8'));
const config=Object.assign({}, values.base);
for(const [k,v] of Object.entries(config)) if(typeof v==='string' && /^\d+(?:\.\d+)?$/.test(v)) config[k]=Number(v);
let expr=config.progressCurrentValueFormula;
for(const [k,v] of Object.entries(config)) expr=expr.replace(new RegExp('\\b'+k+'\\b','g'), v);
console.log(expr);
console.log(eval(expr));
NODE

------
https://chatgpt.com/codex/tasks/task_e_6857166e745c83209755f2e27f381069