### PR TITLE
Fix google images search results

### DIFF
--- a/google-images.html
+++ b/google-images.html
@@ -981,9 +981,13 @@
 
       if (!isValidURL(currentFront)) {
         fFrame.style.display = "block";
-        container.style.display = "block";
-      } else if (!isValidURL(currentBack)) {
+      }
+
+      if (!isValidURL(currentBack)) {
         bFrame.style.display = "block";
+      }
+
+      if (fFrame.style.display === "block" || bFrame.style.display === "block") {
         container.style.display = "block";
       }
 
@@ -1381,13 +1385,13 @@
       const bFrame = document.getElementById("backImageFrame");
 
       if (front && !isValidURL(front)) {
-        fFrame.src = "https://www.google.com/search?tbm=isch&q=" + encodeURIComponent(front);
+        fFrame.src = "https://r.jina.ai/https://www.google.com/search?tbm=isch&q=" + encodeURIComponent(front);
       } else {
         fFrame.src = "";
       }
 
       if (back && !isValidURL(back)) {
-        bFrame.src = "https://www.google.com/search?tbm=isch&q=" + encodeURIComponent(back);
+        bFrame.src = "https://r.jina.ai/https://www.google.com/search?tbm=isch&q=" + encodeURIComponent(back);
       } else {
         bFrame.src = "";
       }


### PR DESCRIPTION
## Summary
- show both front/back image searches when revealing a card
- proxy Google Image searches through `r.jina.ai` so they can display in iframes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68593dc16e308320a83fa7a697239a04