### PR TITLE
Add share button to LoopTube Fusion

### DIFF
--- a/looptube-fusion.html
+++ b/looptube-fusion.html
@@ -37,6 +37,7 @@
     <input id="segments2" type="number" class="form-control" style="max-width:6rem;" value="1" min="1">
     <input id="segments3" type="number" class="form-control" style="max-width:6rem;" value="1" min="1">
     <button id="randPlay" class="btn btn-secondary">Random Play</button>
+    <button id="shareBtn" class="btn btn-primary">Share</button>
   </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
@@ -116,7 +117,23 @@ function checkRand(){
   requestAnimationFrame(checkRand);
 }
 
+function shareLink(){
+  const base='https://sktoushi.github.io/stash-utils/looptube-fusion.html';
+  const p=new URLSearchParams();
+  const u1=document.getElementById('url1').value.trim();
+  const u2=document.getElementById('url2').value.trim();
+  const u3=document.getElementById('url3').value.trim();
+  if(u1)p.set('video1',u1);
+  if(u2)p.set('video2',u2);
+  if(u3)p.set('video3',u3);
+  const link=base+(p.toString()?'?'+p.toString():'');
+  navigator.clipboard.writeText(link)
+    .then(()=>alert('Link copied to clipboard'))
+    .catch(()=>alert('Copy failed'));
+}
+
 document.getElementById('randPlay').onclick=startRandom;
+document.getElementById('shareBtn').onclick=shareLink;
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a Share button under the segment controls
- enable copying a link to LoopTube Fusion with the current URLs preloaded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68594e8992c88320b71f71914b3ad90d