### PR TITLE
Fix history skip for YouTube links

### DIFF
--- a/config/skyway-url-prefix-skip-list
+++ b/config/skyway-url-prefix-skip-list
@@ -11,7 +11,7 @@
   ],
   "contains": [
     "https://youtu.be",
-    "youtube"
+    "youtube",
     "looptube",
     "stash-randomizer",
     "skyway-recent5percent",

--- a/skyway.html
+++ b/skyway.html
@@ -372,7 +372,7 @@ function evalFormula(formula){
 }
 
 async function showProgressAndRedirect(url, rawUrl=null){
-  recordHistory(rawUrl || url);
+  await recordHistory(rawUrl || url);
   await loadConfig();
   const cur = evalFormula(configValues.progressCurrentValueFormula);
   const target = evalFormula(configValues.progressTargetValueFormula);
@@ -592,7 +592,7 @@ async function computeTerminalUrl(){
   let final=null;
   const orig=showProgressAndRedirect;
   try{
-    showProgressAndRedirect=async (url, raw)=>{ recordHistory(raw || url); final=url; };
+    showProgressAndRedirect=async (url, raw)=>{ await recordHistory(raw || url); final=url; };
     await processRows(await fetchCSV(targetCsv));
   }catch(e){ console.error('terminal url capture failed',e); }
   finally{ showProgressAndRedirect=orig; }


### PR DESCRIPTION
## Summary
- await `recordHistory` before redirecting to ensure history is saved
- fix skip list JSON to properly include YouTube entries

## Testing
- `jq . config/skyway-url-prefix-skip-list`

------
https://chatgpt.com/codex/tasks/task_e_685f6d175f9483209aec3893b4ca3e0b