### PR TITLE
Allow logging site URLs in history

### DIFF
--- a/common/history-utils.js
+++ b/common/history-utils.js
@@ -3,7 +3,7 @@ const HIST_STORE='links';
 const HIST_VERSION=1;
 
 function recordHistory(url){
-  if(!url||/^https:\/\/sktoushi.github.io/.test(url)) return;
+  if(!url) return;
   try{
     let arr=JSON.parse(localStorage.getItem('skyway250628v3History')||'[]');
     if(!Array.isArray(arr)) arr=[];

--- a/skyway250628v3.html
+++ b/skyway250628v3.html
@@ -472,7 +472,6 @@ async function getAllHistory(){
 
 /* store non-local links for the history gate */
 function recordHistory(url){
-  if(/^https:\/\/sktoushi.github.io/.test(url)) return;
   let arr;
   try{ arr=JSON.parse(localStorage.getItem('skyway250628v3History')||'[]'); }
   catch{ arr=[]; }

--- a/skyway250628v5.html
+++ b/skyway250628v5.html
@@ -490,7 +490,6 @@ async function recordHistory(url){
   await loadSkipPrefixes();
   if(skipExceptionCache.includes(url)){}else if(skipPrefixCache.some(p=>url.startsWith(p))) return;
   else if(skipKeywordCache.some(k=>url.includes(k))) return;
-  if(/^https:\/\/sktoushi.github.io/.test(url)) return;
   let arr;
   try{ arr=JSON.parse(localStorage.getItem('skyway250628v3History')||'[]'); }
   catch{ arr=[]; }


### PR DESCRIPTION
## Summary
- remove `sktoushi.github.io` filter from common history script
- drop the same filter from `skyway250628v3.html` and `skyway250628v5.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686007626f188320a61157e5ddade9df