### PR TITLE
Add bucket multiverse network preview

### DIFF
--- a/bucket/bucket-multiverse.html
+++ b/bucket/bucket-multiverse.html
@@ -5,6 +5,7 @@
   <title>bucket-multiverse.html – Network Traverser</title>
   <script src="../common/random-utils.js"></script>
   <script src="../common/color-utils.js"></script>
+  <script src="https://d3js.org/d3.v7.min.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <style>
     #portal{display:none;box-sizing:border-box;padding:1rem;max-width:640px;margin:0 auto;height:100%;overflow-y:auto;background:#0d1117;color:#c9d1d9;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Open Sans","Helvetica Neue",sans-serif;}
@@ -24,12 +25,34 @@
   </div>
   <div id="progressSubtext" style="position:fixed;top:calc(50% + 40px);left:50%;transform:translateX(-50%);text-align:center;font-family:Helvetica, sans-serif;font-size:1.5rem;display:none;z-index:9999;"></div>
   <div id="progressCount" style="position:fixed;top:calc(50% + 80px);left:50%;transform:translateX(-50%);text-align:center;font-family:Helvetica, sans-serif;font-size:1.5rem;display:none;z-index:9999;"></div>
+  <div id="network" style="position:fixed;top:0;left:0;width:100%;height:100%;display:none;z-index:9998;"></div>
   <div id="portal"></div>
 <script>
 const DB_NAME='multiverseBuckets';
 const STORE='state';
 const DB_VERSION=1;
 let bucketDb=null, bucketState=null;
+
+let directoryData=null;
+
+async function applyRandomPantoneColor(){
+  try{
+    const resp=await fetch('../pantone-colors.json');
+    const data=await resp.json();
+    const {names,values}=data;
+    if(!names||!values||names.length!==values.length) throw new Error('bad pantone');
+    const idx=Math.floor(getSecureRandomNumber()*names.length);
+    const val=values[idx];
+    document.body.style.backgroundColor=val;
+    const disp=document.getElementById('pantoneColorDisplay');
+    if(disp) disp.textContent=`${names[idx]} (${val})`;
+    window.lastPantoneColor=val;
+  }catch(e){
+    console.error('Pantone color load failed',e);
+    document.body.style.backgroundColor='#ffffff';
+    window.lastPantoneColor='#ffffff';
+  }
+}
 
 const HIST_DB_NAME='multiverseHistory';
 const HIST_STORE='links';
@@ -174,6 +197,7 @@ function getPhilippineNow(){
 async function loadDirectory(){
   const resp=await fetch('bucket-directory.json');
   const data=await resp.json();
+  directoryData=data;
   function walk(obj,path){
     for(const [k,v] of Object.entries(obj)){
       if(Array.isArray(v)){
@@ -371,8 +395,65 @@ async function importData(txt){
 }
 function resetData(){const r=indexedDB.deleteDatabase(HIST_DB_NAME);r.onsuccess=()=>location.reload();}
 
+function buildGraphData(){
+  if(!directoryData) return {nodes:[],links:[]};
+  const nodes=[]; const links=[]; const map={};
+  function ensure(id,type){ if(!map[id]){ map[id]={id,type,count:0}; nodes.push(map[id]); } return map[id]; }
+  ensure('root','cat');
+  function walk(obj,path){
+    for(const [k,v] of Object.entries(obj)){
+      if(Array.isArray(v)){
+        const parent=ensure(path.join('/')||'root','cat');
+        for(const item of v){
+          const n=ensure(item.id,'item');
+          n.count=(bucketState?.counts[item.id])||0;
+          links.push({source:parent.id,target:n.id});
+        }
+      }else if(typeof v==='object'){
+        const parent=ensure(path.join('/')||'root','cat');
+        const key=path.concat(k).join('/');
+        ensure(key,'cat');
+        links.push({source:parent.id,target:key});
+        walk(v,path.concat(k));
+      }
+    }
+  }
+  walk(directoryData,[]);
+  return {nodes,links};
+}
+
+async function drawNetwork(){
+  const {nodes,links}=buildGraphData();
+  const div=document.getElementById('network');
+  div.style.display='block';
+  div.innerHTML='';
+  const width=div.clientWidth, height=div.clientHeight;
+  const svg=d3.select(div).append('svg').attr('width',width).attr('height',height);
+  const link=svg.append('g').selectAll('line').data(links).enter().append('line').attr('stroke','#999').attr('stroke-opacity',0.6);
+  const node=svg.append('g').selectAll('circle').data(nodes).enter().append('circle')
+    .attr('r',d=>d.type==='item'?5+2*d.count:8)
+    .attr('fill',d=>d.type==='item'?'#69b3a2':'#ffdd57');
+  node.append('title').text(d=>d.id);
+  const sim=d3.forceSimulation(nodes)
+    .force('link',d3.forceLink(links).id(d=>d.id).distance(50))
+    .force('charge',d3.forceManyBody().strength(-50))
+    .force('center',d3.forceCenter(width/2,height/2));
+  sim.on('tick',()=>{
+    link.attr('x1',d=>d.source.x).attr('y1',d=>d.source.y)
+        .attr('x2',d=>d.target.x).attr('y2',d=>d.target.y);
+    node.attr('cx',d=>d.x).attr('cy',d=>d.y);
+  });
+  return new Promise(res=>setTimeout(()=>{sim.stop();div.style.display='none';res();},4000));
+}
+
+async function showNetworkAndRedirect(url){
+  try{ await drawNetwork(); }
+  catch(e){ console.error('graph fail',e); }
+  await showProgressAndRedirect(url);
+}
+
 async function runOriginal(){
-  await getRandomColor();
+  await applyRandomPantoneColor();
   await loadConfig();
   animateProgressCount();
   const count=updateVisitCounter();
@@ -387,7 +468,7 @@ async function runOriginal(){
   }
   await loadBucketState();
   const url=pickBucketItem();
-  if(url) await showProgressAndRedirect(url);
+  if(url) await showNetworkAndRedirect(url);
   else document.body.textContent='No bucket items available.';
 }
 
@@ -413,7 +494,7 @@ async function runHistoryGate(){
     const score=(now-r.lastSeen)/(r.freq+1);
     if(score>bestScore){ bestScore=score; best=r; }
   }
-  await showProgressAndRedirect(best.url);
+  await showNetworkAndRedirect(best.url);
 }
 
 window.onload=async()=>{


### PR DESCRIPTION
## Summary
- show dynamic Pantone color from parent directory
- render network of bucket items sized by review counts
- delay redirect until network preview finishes

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_686011469bc08320a782539adfe00149