### PR TITLE
Fix syntax error in skyway.html

### DIFF
--- a/skyway.html
+++ b/skyway.html
@@ -182,7 +182,7 @@ async function runSrsGate(){
   useSrsLayer = false;
   return false;
 }
-  ║  HIERARCHICAL DECISION STACK             ║
+/* ║  HIERARCHICAL DECISION STACK             ║
   ║  1) modeWeights  → chooses randomMode.   ║
   ║  2) distributions / distribution         ║
   ║     • if present → forces “segments”.    ║


### PR DESCRIPTION
## Summary
- comment out ASCII-art section in `skyway.html` causing `Invalid or unexpected token`

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_686103a1bef08320b0457e1b5028246e