### PR TITLE
Improve c25v2 tracker

### DIFF
--- a/c25v2.html
+++ b/c25v2.html
@@ -4,6 +4,15 @@
   <meta charset="UTF-8">
   <title>c25 Tracker</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body { background-color:#0d1117; color:#c9d1d9; }
+    .card, .alert { background-color:#161b22; border-color:#30363d; color:#c9d1d9; }
+    .form-control, .form-select { background-color:#161b22; color:#c9d1d9; border-color:#30363d; }
+    .btn-primary { background-color:#238636; border-color:#238636; }
+    .btn-danger { background-color:#da3633; border-color:#da3633; }
+    .btn-secondary { background-color:#57606a; border-color:#57606a; color:#c9d1d9; }
+    .progress { background-color:#30363d; }
+  </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 </head>
 <body class="bg-light p-4">
@@ -32,7 +41,7 @@
       </div>
       <div class="col-12 col-lg-2">
         <label class="form-label" for="dateInput">YYYYMM</label>
-        <input type="text" pattern="\\d{6}" id="dateInput" class="form-control" required>
+        <input type="text" pattern="[0-9]{6}" id="dateInput" class="form-control" required>
       </div>
       <div class="col-12 col-lg-2">
         <label class="form-label" for="amountInput">Amount (±)</label>
@@ -53,8 +62,26 @@
         <label class="form-label" for="newCategoryInput">New Category</label>
         <input type="text" id="newCategoryInput" class="form-control">
       </div>
+      <div class="col-12 col-lg-2">
+        <label class="form-label" for="newCategoryColor">Color</label>
+        <select id="newCategoryColor" class="form-select"></select>
+      </div>
       <div class="col-12 col-lg-1">
         <button class="btn btn-secondary w-100" type="submit">Add Category</button>
+      </div>
+    </form>
+
+    <form id="colorForm" class="row row-cols-lg-auto g-2 align-items-end mt-3">
+      <div class="col-12 col-lg-2">
+        <label class="form-label" for="colorCategorySelect">Category</label>
+        <select id="colorCategorySelect" class="form-select"></select>
+      </div>
+      <div class="col-12 col-lg-2">
+        <label class="form-label" for="colorSelect">Color</label>
+        <select id="colorSelect" class="form-select"></select>
+      </div>
+      <div class="col-12 col-lg-1">
+        <button class="btn btn-secondary w-100" type="submit">Set Color</button>
       </div>
     </form>
 
@@ -75,6 +102,25 @@
     const KEY = 'data';
     const goal = 4100;
     let chartInstance;
+
+    const metroColors = {
+      green: '#00a300',
+      red: '#E51400',
+      blue: '#1BA1E2',
+      orange: '#F0A30A',
+      purple: '#6A00FF',
+      teal: '#00ABA9'
+    };
+
+    function ensureColorMap() {
+      data._colors ||= {};
+      Object.keys(data).forEach(k => {
+        if (k === '_colors') return;
+        if (!data._colors[k]) {
+          data._colors[k] = k === 'x' ? metroColors.red : metroColors.green;
+        }
+      });
+    }
 
     // ***** IndexedDB helpers *****
     function openDB() {
@@ -109,6 +155,7 @@
       data = await fetch('config/c25.json').then(r => r.json());
       await idbSet(db, data);
     }
+    ensureColorMap();
 
     const dateInput = document.getElementById('dateInput');
     function setCurrentYM() {
@@ -117,13 +164,43 @@
     }
 
     const categorySelect = document.getElementById('categorySelect');
+    const newCategoryColor = document.getElementById('newCategoryColor');
+    const colorCategorySelect = document.getElementById('colorCategorySelect');
+    const colorSelect = document.getElementById('colorSelect');
+
+    function populateColorOptions() {
+      if (newCategoryColor) newCategoryColor.innerHTML = '';
+      if (colorSelect) colorSelect.innerHTML = '';
+      Object.entries(metroColors).forEach(([name, val]) => {
+        const opt1 = document.createElement('option');
+        opt1.value = val;
+        opt1.textContent = name;
+        if (newCategoryColor) newCategoryColor.appendChild(opt1);
+        const opt2 = document.createElement('option');
+        opt2.value = val;
+        opt2.textContent = name;
+        if (colorSelect) colorSelect.appendChild(opt2);
+      });
+      if (newCategoryColor) newCategoryColor.value = metroColors.green;
+      if (colorSelect) colorSelect.value = metroColors.green;
+    }
+    function categoryTotals() {
+      return Object.entries(data)
+        .filter(([k]) => k !== '_colors')
+        .map(([k, entries]) => [k, Object.values(entries).reduce((s, e) => s + e.value, 0)]);
+    }
+
     function populateCategories() {
+      const totals = categoryTotals().sort((a, b) => b[1] - a[1]);
       categorySelect.innerHTML = '';
-      Object.keys(data).forEach(k => {
+      const colorCatSel = document.getElementById('colorCategorySelect');
+      if (colorCatSel) colorCatSel.innerHTML = '';
+      totals.forEach(([k]) => {
         const opt = document.createElement('option');
         opt.value = k;
         opt.textContent = k;
         categorySelect.appendChild(opt);
+        if (colorCatSel) colorCatSel.appendChild(opt.cloneNode(true));
       });
     }
 
@@ -134,13 +211,19 @@
       container.innerHTML = '';
       const labels = [];
       const values = [];
+      const colors = [];
       let positiveTotal = 0;
       let xValue = 0;
       let xTime = 0;
       let aggregateValue = 0;
       let aggregateTime = 0;
 
-      Object.entries(data).forEach(([key, entries]) => {
+      const totalsArr = categoryTotals().sort((a,b)=>b[1]-a[1]);
+      const ordered = totalsArr.map(([k])=>k);
+      const baseline = totalsArr.length ? totalsArr[0][1] : 0;
+
+      ordered.forEach(key => {
+        const entries = data[key];
         let valueSum = 0;
         let timeSum = 0;
         Object.values(entries).forEach(e => {
@@ -150,6 +233,7 @@
         const rate = timeSum ? valueSum / timeSum : 0;
         labels.push(key);
         values.push(valueSum);
+        colors.push(data._colors[key] || metroColors.green);
 
         if (key !== 'b1' && key !== 'x') {
           aggregateValue += valueSum;
@@ -165,7 +249,7 @@
         const div = document.createElement('div');
         div.className = 'mb-3';
         if (key !== 'x') {
-          const pct = (valueSum / goal) * 100;
+          const pct = baseline ? (valueSum / baseline) * 100 : 0;
           let note = '';
           if (rate > 0 && valueSum < goal) {
             const days = (goal - valueSum) / rate;
@@ -175,9 +259,9 @@
           div.innerHTML = `
             <h5>${key} (${valueSum} / ${goal})</h5>
             <div class="progress">
-              <div class="progress-bar ${pct>=100?'bg-success':'bg-info'}" role="progressbar"
-                   style="width: ${Math.min(pct, 100).toFixed(2)}%;" aria-valuenow="${pct.toFixed(2)}"
-                   aria-valuemin="0" aria-valuemax="100">${pct.toFixed(2)}%</div>
+              <div class="progress-bar" role="progressbar"
+                   style="width: ${Math.min(pct, 100).toFixed(2)}%; background-color:${data._colors[key]};"
+                   aria-valuenow="${pct.toFixed(2)}" aria-valuemin="0" aria-valuemax="100">${pct.toFixed(2)}%</div>
             </div>
             ${note ? `<small class="text-muted">${note}</small>` : ''}
           `;
@@ -217,14 +301,19 @@
         type: 'bar',
         data: {
           labels,
-          datasets: [{ label: 'Current Value', data: values, borderWidth: 1 }]
+          datasets: [{ label: 'Current Value', data: values, backgroundColor: colors, borderWidth: 1 }]
         },
         options: {
-          scales: { y: { beginAtZero: true, max: goal } }
+          scales: {
+            x: { ticks: { color: '#c9d1d9' } },
+            y: { beginAtZero: true, max: baseline || goal, ticks: { color: '#c9d1d9' } }
+          },
+          plugins: { legend: { labels: { color: '#c9d1d9' } } }
         }
       });
     }
 
+    populateColorOptions();
     populateCategories();
     render();
     setCurrentYM();
@@ -264,7 +353,9 @@
       try {
         const imported = JSON.parse(await file.text());
         data = imported;
+        ensureColorMap();
         await idbSet(db, data);
+        populateColorOptions();
         populateCategories();
         render();
         e.target.value = '';
@@ -277,19 +368,35 @@
     document.getElementById('categoryForm').addEventListener('submit', async (e) => {
       e.preventDefault();
       const name = document.getElementById('newCategoryInput').value.trim();
+      const color = document.getElementById('newCategoryColor').value;
       if (!name || data[name]) return;
       data[name] = {};
+      data._colors[name] = color || metroColors.green;
       await idbSet(db, data);
+      populateColorOptions();
       populateCategories();
       categorySelect.value = name;
       document.getElementById('newCategoryInput').value = '';
+    });
+
+    document.getElementById('colorForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const cat = document.getElementById('colorCategorySelect').value;
+      const color = document.getElementById('colorSelect').value;
+      if (!cat) return;
+      data._colors[cat] = color;
+      await idbSet(db, data);
+      populateColorOptions();
+      render();
     });
 
     // ***** Clear Data *****
     document.getElementById('clearBtn').addEventListener('click', async () => {
       if (!confirm('Clear all stored data?')) return;
       data = {};
+      ensureColorMap();
       await idbSet(db, data);
+      populateColorOptions();
       populateCategories();
       render();
       setCurrentYM();


### PR DESCRIPTION
## Summary
- fix date validation pattern
- add GitHub-inspired dark mode
- reorder categories by highest value and use it as baseline for the others
- allow per-category color selection with Metro-style palette

## Testing
- `node - <<'EOF'
const fs=require('fs');
let html=fs.readFileSync('c25v2.html','utf8');
let script=html.match(/<script>([\s\S]*)<\/script>/)[1];
try{new Function(script);console.log('ok');}
catch(e){console.error('error',e.message);process.exit(1);}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6863d0a492b88320bae15f810bf55b73