### PR TITLE
Simplify forecast calculations

### DIFF
--- a/c25v2.html
+++ b/c25v2.html
@@ -223,12 +223,16 @@
       ordered.forEach(key => {
         const entries = data[key];
         let valueSum = 0;
-        let rateSum = 0;
+        let rate = 0;
+        const latest = Object.entries(entries)
+          .sort((a,b)=>b[0].localeCompare(a[0]))[0];
+        if (latest) {
+          const e = latest[1];
+          rate = e.value / e.time;
+        }
         Object.values(entries).forEach(e => {
           valueSum += e.value;
-          rateSum += e.value / e.time;
         });
-        const rate = rateSum;
         labels.push(key);
         values.push(valueSum);
         colors.push(data._colors[key] || metroColors.green);


### PR DESCRIPTION
## Summary
- calculate forecast rate using only the newest entry for each category

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6863d88c8c10832097c399b34b00d1c3